### PR TITLE
PRD-4101, PRD-4424 Report Viewer

### DIFF
--- a/package-res/reportviewer/report.html
+++ b/package-res/reportviewer/report.html
@@ -118,7 +118,7 @@
     </script>	    
   </head>
   
-  <body class="tundra body styled">
+  <body class="tundra body">
     <div id="toppanel" class="pentaho-transparent hidden">
       <div id="toppanelinner" >
         <div id="toolbarlinner2" class="pentaho-rounded-panel2-shadowed pentaho-padding-sm pentaho-shine pentaho-background">
@@ -149,7 +149,6 @@
             	this.parameterValidityCallback(false);
       		}
           };
-          
         </script>
 
         <div id="reportControlPanel" class="hidden pentaho-rounded-panel-bottom-lr pentaho-shadow">
@@ -157,8 +156,13 @@
         </div>
       </div>
     </div>
-
-	<iframe id="reportContent" frameborder="0" style="width:100%"></iframe>
+    <!-- It's hard to get a 0-height empty div in IE... -->
+    <div id="reportAreaTop" style="visibility:hidden;height:0px;width:0px;margins:0px;paddings:0px;font-size:0px;line-height:0px;position:static;display:block;"></div>
+    <div id="reportArea" class="pentaho-transparent" style="visibility:hidden;" scrollexception="true">
+	  <div id="reportPageOutline">
+	    <iframe id="reportContent" frameborder="0" style="width:100%;"></iframe>
+	  </div>
+	</div>
 	
     <div id="messageBox" dojoType="pentaho.common.MessageBox" title="" style="width:400px; display:none;">
     </div>

--- a/package-res/reportviewer/reportviewer.css
+++ b/package-res/reportviewer/reportviewer.css
@@ -24,10 +24,15 @@ div.prompt-panel {
 }
 
 #reportArea {
-  padding: 8px 0 8px 0;
-  overflow: auto;
+  padding: 0;
+  overflow: hidden;
   /* Required to be position: relative for IE7 so that the reportPageOutline can be properly scrolled and will not overflow. */
   position: relative;
+}
+
+.styled #reportArea {
+  padding: 8px 0 8px 0;
+  overflow: auto;
 }
 
 .dj_ie7 #reportArea {
@@ -225,3 +230,17 @@ div.prompt-panel {
     padding-right: 8px; 
     padding-bottom: 8px;
 }
+
+/* Debugging styles for report area
+#reportArea {
+	border: solid 3px green;
+}
+
+#reportPageOutline {
+	border: solid 3px red;
+}
+
+#reportContent {
+	border: solid 3px yellow;
+}
+ */

--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -1,9 +1,11 @@
 pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/util/timeutil', 'common-ui/util/formatting'], function(util) {
+  
   return function(reportPrompt) {
     if (!reportPrompt) {
-    	alert("report prompt is required");
-    	return;
+      alert("report prompt is required");
+      return;
     }
+
     var v = {
       prompt: reportPrompt,
 
@@ -20,28 +22,42 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
           this.view.togglePromptPanel();
         }.bind(this));
 
-
         this.view.resize();
-        var viewResizeIframe = this.view.resizeIframe.bind(this.view);
-        $('#reportContent').load(function() {
-      	var iframe = this;
-          // Schedule the resize after the document has been rendered and CSS applied
-          setTimeout(function() {
-            viewResizeIframe(iframe);
+        
+        var boundOnReportContentLoaded = this._onReportContentLoaded.bind(this);
+        
+        // Schedule the resize after the document has been rendered and CSS applied
+        var onFrameLoaded = function() { setTimeout(boundOnReportContentLoaded); };
+        
+        if(dojo.isIE){
+          // When a file is downloaded, the "complete" readyState does not occur: "loading", "interactive", and stops. 
+          dojo.connect(dojo.byId('reportContent'), "onreadystatechange", function() {
+            if(this.readyState === 'complete') { onFrameLoaded(); }
           });
-        });
+        } else {
+          dojo.connect(dojo.byId('reportContent'), "load", onFrameLoaded);
+        }
+        
+        this.prompt.ready       = this.promptReady.bind(this);
+        this.prompt.submit      = this.submitReport.bind(this);
+        this.prompt.submitStart = this.submitReportStart.bind(this);
 
-        this.prompt.schedule = this.scheduleReport.bind(this);
-        this.prompt.submit = this.submitReport.bind(this);
-
+        
+        // The following is *not* consusing :-/
+        
+        // Default implementation of this.prompt.initPromptPanel
+        // calls this.prompt.panel.init();
         var decorated = this.prompt.initPromptPanel.bind(this.prompt);
 
         this.prompt.initPromptPanel = function() {
           // Decorate the original init to first initialize our view then the panel
-          var init = this.prompt.panel.init;
-            this.prompt.panel.init = function() {
+          var panel = this.prompt.panel;
+          var init  = panel.init;
+
+          panel.init = function() {
             this.view.init(init, this.prompt.panel);
           }.bind(this);
+
           decorated();
         }.bind(this);
 
@@ -49,9 +65,6 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
       },
 
       view: {
-        // The last known report width so we can set an empty page to a decent width so it doesn't change drastically between refreshes.
-        lastWidth: 700,
-
         /**
          * Localize the Report Viewer.
          */
@@ -68,48 +81,68 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
           /**
            * If we're not in PUC or we're in an iframe
            */
-           var mobile = false;
-           try{
-            mobile = window.top.PentahoMobile;
-           } catch(e){}
-
-          var puc = window.top.mantle_initialized;
-          var iframe = top !== self;
+          var mobile = this.isPentahoMobileEnv();
+          var inPuc  = window.top.mantle_initialized;
+          var inIFrame = top !== self;
+          
           // if we are not in PUC
-          if(!inSchedulerDialog && !mobile && (!puc || iframe)) {
+          if(!inSchedulerDialog && !mobile && (!inPuc || inIFrame)) {
             dojo.addClass(document.body, 'pentaho-page-background');
           }
         },
 
-        /**
-         * Sets the report content visible if it should be:
-         *  - Prompts are valid
-         *  - The prompt panel allows auto-submit or the prompts were changed by the user
-         *
-         * We must always show the report content if we're not in 'REPORT' render mode because this area is used to provide
-         * feedback to the user.
-         *
-         * @param promptPanel The current prompt panel
-         * @param renderMode Current render mode: 'REPORT' or 'SUBSCRIBE'
-         */
-        updateReportContentVisibility: function (promptPanel, renderMode) {
-            // PRD-4271:
-            // If 'Auto Submit' checkbox is set, we will always re-render the report.  However, don't re-render report
-            // if there is no initial report content displayed.
-            // The server is hit when parameters change in parameter panel so that we can check for parameter
-            // updates in case of parameter cascading (even if auto-submit is not set).
-            // If auto-submit is enabled, then we update the report after each parameter has been entered only if we have
-            // an initial report displayed.
-            var reportContentElement = dojo.byId('reportContent');
-            var visibility = true;
-            if ((!promptPanel.paramDefn.allowAutoSubmit()) && (renderMode === 'REPORT') &&
-                    ((((reportContentElement.src === '') || (reportContentElement.src === 'about:blank')) && (prompt.mode !== 'MANUAL')) ||
-                            (!promptPanel.paramDefn.promptNeeded && (prompt.mode === 'INITIAL'))))
-            {
-                visibility = false;
+        updateReportContentVisibility: function(promptPanel) {
+          this._showReportContent(this._calcReportContentVisibility(promptPanel));
+        },
+        
+        _showReportContent: function(visible, preserveSource) {
+          var area = $('#reportArea');
+          
+          var content = $('#reportContent');
+          if (!visible) {
+            if(!preserveSource && this._hasReportContent()) { // Don't touch "src" of a already blank iframe, or onloads occur... 
+              content.attr("src", 'about:blank');
             }
+            
+            // PRD-4271 Don't show white box rectangle...
+            // PRD-4018, PRD-4034 FF & IE8 does not resize properly when iframe is hidden
+            // So we hide it placing the iframe off-page
+            // Also, cannot hide (vibility/display) a parent of the iframe where a pdf is to be shown
+            // otherwise loading fails in IE.
+            area.css({
+                 position: 'absolute',
+                 left:   -100000,
+                 top:    -100000
+              });
+          } else {
+            // Remove the "visibility:hidden" placed in the HTML
+            // to avoid flicker in first time.
+            area.css({position: 'static'}).css({visibility: 'inherit'});
+          }
+        },
+        
+        _calcReportContentVisibility: function(promptPanel) {
+          var visible = 
+            // Anything in the iframe to show? (PRD-4271)
+            this._hasReportContent() &&
 
-            this.showReportContent(visibility);
+            // Valid data (although report content should be blank here)
+            !promptPanel.paramDefn.promptNeeded &&
+
+            // Hide the report area when in the "New Schedule" dialog
+            !inSchedulerDialog &&
+
+            (promptPanel.forceAutoSubmit || 
+             promptPanel.paramDefn.allowAutoSubmit() || // (BISERVER-6915)
+             prompt.mode === 'MANUAL');
+          
+          return visible;
+        },
+
+        _hasReportContent: function() {
+          var iframe = dojo.byId('reportContent');
+          var src = iframe.src;
+          return src !== '' && src !== 'about:blank';
         },
 
         init: function(init, promptPanel) {
@@ -119,50 +152,62 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
             dojo.addClass('toolbar-parameterToggle', 'hidden');
           }
 
+          this._layoutInited = false;
+          
+          // May call submit, in which case submitReport is called without _initLayout...
           init.call(promptPanel);
-          this.configureLayout(promptPanel);
+          this._initLayout(promptPanel);
         },
 
         /**
-         * Configure the report viewer's layout based on the loaded parameter definition.
+         * Initializes the report viewer's layout based on the loaded parameter definition.
          *
          * @param promptPanel A prompt panel whose settings should be used to configure the report viewer
          */
-        configureLayout: function(promptPanel) {
-          this.showPromptPanel(promptPanel.paramDefn.showParameterUI());
-          this.updateReportContentVisibility(promptPanel, 'REPORT');
-          this.refreshPageControl(promptPanel);
-
-          if (!promptPanel.paramDefn.paginate && !promptPanel.paramDefn.showParameterUI()) {
-            // Hide the toolbar when it would be empty and unstyle the report so it's the only visible element when both the
-            // pagination controls and the parameter UI are hidden
-            dojo.addClass('toppanel', 'hidden');
-            this.updatePageStyling(false);
-          } else {
-            // Make sure the toolbar is visible
-            dojo.removeClass('toppanel', 'hidden');
+        _initLayout: function(promptPanel) {
+          if(this._layoutInited) { return; }
+          
+          // Don't mess with the parameters if we're "navigating".
+          // If the user has explicitly hidden the UI, 
+          // and is going through several pages, 
+          // we should not keep popping the UI again on each page init...
+          // PRD-4001, PRD-4102
+          var navigating  = !!this._initedOnce; //this._hasReportContent();
+          this._initedOnce = true;
+          
+          var showParamUI = promptPanel.paramDefn.showParameterUI();
+          if(showParamUI && !navigating && this.isPentahoMobileEnv() && 
+             !promptPanel.paramDefn.promptNeeded && promptPanel.paramDefn.allowAutoSubmit()) {
+            // Don't show parameter panel by default unless prompt needed?
+            showParamUI = false;
           }
           
-          this.resize();
+          if(!navigating || !showParamUI) {
+            this.showPromptPanel(showParamUI);
+          }
+          
+          this.updateReportContentVisibility(promptPanel);
+          this.updatePageControl(promptPanel);
+
+          // Hide the toolbar, 'toppanel',  when it would be empty and 
+          // un-style the report so it's the only visible element 
+          // when both the pagination controls and the parameter UI are hidden.
+          var isToolbarEmpty = !promptPanel.paramDefn.paginate && !showParamUI;
+          dojo[isToolbarEmpty ? 'addClass' : 'removeClass']('toppanel', 'hidden');
+          
+          this._layoutInited = true;
         },
 
-        showReportContent: function(visible) {
-          var toggle = visible ? dojo.removeClass : dojo.addClass;
-          var selector = this.isPageStyled() ? 'reportArea' : 'reportContent';
-          toggle(selector, 'hidden');
-          if (!visible) {
-            $('#reportContent').attr("src", 'about:blank');
-          }
+        show: function() {
+          // Cleans up an issue where sometimes on show the iframe is offset
+          this.resizeIFrame();
         },
-        
-        show: function(){
-        //Cleans up an issue where somtimes on show the iframe is offset
-        resizeIframe($('#reportContent'))
-        },
-        
-        refreshPageControl: function(promptPanel) {
+
+        updatePageControl: function(promptPanel) {
           var pc = dijit.byId('pageControl');
+          
           pc.registerPageNumberChangeCallback(undefined);
+          
           if (!promptPanel.paramDefn.paginate) {
             promptPanel.setParameterValue(promptPanel.paramDefn.getParameter('accepted-page'), '-1');
             pc.setPageCount(1);
@@ -181,14 +226,15 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
             pc.setPageCount(total);
             pc.setPageNumber(page + 1);
           }
-          pc.registerPageNumberChangeCallback(function(pageNumber) {
-            this.pageChanged(promptPanel, pageNumber);
+          
+          pc.registerPageNumberChangeCallback(function(pageNumber) { 
+            this.pageChanged(promptPanel, pageNumber); 
           }.bind(this));
         },
 
         pageChanged: function(promptPanel, pageNumber) {
           promptPanel.setParameterValue(promptPanel.paramDefn.getParameter('accepted-page'), '' + (pageNumber - 1));
-          promptPanel.submit(promptPanel);
+          promptPanel.submit(promptPanel, {isPageChange: true});
         },
 
         togglePromptPanel: function() {
@@ -197,166 +243,194 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
         },
 
         showPromptPanel: function(visible) {
-          if (visible) {
-            dijit.byId('toolbar-parameterToggle').set('checked', true);
-            dojo.removeClass('reportControlPanel', 'hidden');
-          } else {
-            dijit.byId('toolbar-parameterToggle').set('checked', false);
-            dojo.addClass('reportControlPanel', 'hidden');
-          }
+          dijit.byId('toolbar-parameterToggle').set('checked', !!visible);
+          
+          dojo[visible ? 'removeClass' : 'addClass']('reportControlPanel', 'hidden');
         },
 
         isPageStyled: function() {
-          return $('#reportArea').length === 1;
+          return $('body').hasClass('styled');
         },
 
-		isPentahoMobileEnv: function() {
-		  return (typeof window.top.PentahoMobile !== 'undefined');
-		},
+        isPentahoMobileEnv: function() {
+          return (typeof window.top.PentahoMobile !== 'undefined');
+        },
 
         updatePageStyling: function(styled) {
-          var currentlyStyled = this.isPageStyled();
-          if (styled) {          
-            if (this.isPentahoMobileEnv()) {
-              $('body').addClass('styled');
-            } else {
-              // Style the report iframe if it's not already styled
-              if (!currentlyStyled) {
-                var iframe = $('#reportContent');
-                $('body').addClass('styled');
-                iframe.wrap('<div id="reportArea" class="pentaho-transparent" scrollexception="true"/>');
-                iframe.wrap('<div id="reportPageOutline" class="pentaho-rounded-panel2-shadowed pentaho-padding-lg pentaho-background"/>');
-              }
+          // normalize to boolean
+          styled = !!styled;
+          
+          // Need to style at least the first time anyway, 
+          // to ensure the HTML and JS are in sync.
+          if(!this._pageStyledOnce || this.isPageStyled() !== styled) {
+            this._pageStyledOnce = true;
+            
+            var setClass = styled ? 'addClass' : 'removeClass';
+            
+            $('body')[setClass]('styled');
+            
+            if(!styled) {
+              $('#reportArea').css({width: 'auto', height: 'auto'});
+              $('#reportPageOutline').css({width: 'auto', height: 'auto'});
+              $('#reportContent').css({width: window.innerWidth});
             }
-          } else {
-            if (currentlyStyled) {
-              $('body').removeClass('styled');
-              var iframe = $('#reportContent');
-              if (this.isPentahoMobileEnv()) {
-                iframe.css('width', window.innerWidth);
-              } else {
-                iframe.css('width', window.innerWidth);
-                iframe.unwrap().unwrap();
-              }
-            }
+            
+            $('#reportPageOutline')[setClass]('pentaho-rounded-panel2-shadowed pentaho-padding-lg pentaho-background');
+            
+            this.resize();
           }
-          this.resize();
         },
 
         resize: function() {
-          if (this.isPentahoMobileEnv()) {
-	        $('#reportControlPanel').css('width', window.top.innerWidth);   
-                var iframe = $('#reportContent')[0];
-				var t = $(iframe);
-	          	var frameDoc = iframe.contentWindow.document;
-	           	var reportTable = frameDoc.body.childNodes[1];
-	           	if (reportTable != null) {
-	           		dojo.byId('reportContent').setAttribute('scrolling', 'no')
-	           		var c = dojo.coords(dojo.byId('reportContent'));					
-					var divHeight = window.innerHeight - c.y - 3;
-	           		t.height(divHeight);
-					t.width(window.top.innerWidth);
-	           		
-	           		var reportTableDiv = frameDoc.getElementById('reportTableDiv');
-	           		// check if already wrapped
-	               	if (reportTableDiv != null) {
-	               		dojo.style(reportTableDiv, 'height', divHeight + 'px');
-	               		dojo.style(reportTableDiv, 'overflow', 'auto');
-	               	} else {
-	                   	$(reportTable).wrap('<div id="reportTableDiv" style="height:' + divHeight + 'px; overflow:auto"/>');          		                     		
-	               	}
-	           	} 			
+          // NOTE: reportContent/reportArea are not always correctly positioned: 
+          // they are placed off-page, when "hidden", 
+          // to avoid flicker and still allow layout and measure poling.
+          //
+          // That's why the dummy "reportAreaTop" is used to find the desired target's height (mb.h).
+          // TODO: possibly, using the box-model & visibility we could determine the y position
+          // from the "toppanel" element; couldn't get it to work; 
+          // probably wasn't taking all the needed margins/paddings into account.
+          // 
+          // Target extends to all available width.
+          var c  = dojo.coords(dojo.byId('reportAreaTop'));
+          var vp = dojo.dnd.getViewport();
+          var mb = {h: vp.h - c.y, w: vp.w};
+          
+          var target;
+          if(this.isPageStyled()) { // Mobile is *never* styled
+            target = 'reportArea';
           } else {
-            var ra = dojo.byId(this.isPageStyled() ? 'reportArea' : 'reportContent');
-            var c = dojo.coords(ra);
-            var windowHeight = dojo.dnd.getViewport().h;
-            dojo.marginBox(ra, {h: windowHeight - c.y});
+            // When page is !styled, "reportArea" has height auto.
+            // The iframe is sized with the viewport height, 
+            // causing the scroll-bar to be provided by iframe's content itself.
+            target = 'reportContent';
+                        
+            // NOTE: care had to be taken to remove the reportArea's paddings/margins in CSS/stylesheet
+            // otherwise, the height of reportContent would need to take these into account.
+            // Also, as the height would exceed the window height, then had problems
+            // in iPad/iOS6/Safari due to show scroll/hide scroll instability, causing repeated
+            // resize events to occur.
+            
+            // NOTE2: There's still a problem (at least) in iPad/iOS6/Safari, and (at least) with HTML, 
+            // where showing the prompts (when initially hidden), and even though the "resize" gets called,
+            // the height is not correctly changed, and 
+            // a part of the report gets cut-off at the bottom.
+          }
+          
+          dojo.marginBox(target, mb);
+          
+          if(this.isPentahoMobileEnv()) {
+            $('#reportControlPanel').css('width', vp.w);
+            
+            // HACK into the report content's HTML so that it handles scrolling directly
+            if(this._isHtmlReport) {
+              var iframe   = dojo.byId('reportContent');
+              var frameDoc = iframe.contentWindow.document;
+              var reportTable = frameDoc.body.childNodes[1];
+              if (reportTable) {
+                iframe.setAttribute('scrolling', 'no');
+                
+                // TODO: HACK: Avoid a slightly clipped footer (heuristic value)
+                var wh = mb.h - 15;
+                
+                // Find wrapper element
+                var reportTableDiv = frameDoc.getElementById('reportTableDiv');
+                if (reportTableDiv != null) {
+                  dojo.style(reportTableDiv, 'height', wh + 'px');
+                  dojo.style(reportTableDiv, 'overflow', 'auto');
+                } else {
+                  $(reportTable).wrap('<div id="reportTableDiv" style="height:' + wh + 'px; overflow:auto;"/>');
+                }
+              }
+            }
           }
         },
-
-        resizeIframe: function(iframe) {
-          var t = $(iframe);
-          
-		  
-          if (!this.isPageStyled() && !this.isPentahoMobileEnv()) {
-            return;
-          }
-
-          if (t.attr('src') === 'about:blank') {
-            // use the last known report width (or the default) so we don't drastically change the width between refreshes
-            t.width(this.lastWidth); // matches report.css: .styled >* #reportContent
-            if (!this.isPentahoMobileEnv()) {
-              t.height(200);
-              $('#reportPageOutline').width(t.outerWidth() + 14);
-              this.resize();
-            }
-          }
-          else {
-          // Reset the iframe height before polling its contents so the size is correct.
-
-            if(!dojo.isFF && (dojo.isIE != 8)){ // PRD-4018, PRD-4034 FF & IE8 does not resize properly when iframe is hidden
-              t.hide(); // PRD-4000 Hide iframe before resize
-            }
-
-            if (!this.isPentahoMobileEnv()) {
-              t.width(0);
-              t.height(0);
-
-              var d = $(iframe.contentWindow.document);
-              t.height(d.height());
-
-              this.lastWidth = d.width();
-              t.width(this.lastWidth);
+        
+        /**
+         * Adjusts the report content iframe's width and height.
+         * The result is affected by:
+         * <ul> 
+         *   <li>content existing or not</li>
+         *   <li>being in a mobile environment or not</li>
+         *   <li>the existing content being styled</li>
+         *   <li>the viewport size.</li>
+         * </ul>
+         *  
+         * Finally, the {@link #resize} method is called,
+         * that adjusts the report area div, 
+         * responsible by showing up a scrollbar, when necessary.  
+         */ 
+        resizeIFrame: function() {
+          if (this._hasReportContent()) {
+            // PRD-4000 Hide iframe before resize
+            this._showReportContent(false, /*preserveSource*/true);
+            
+            if (this.isPageStyled()) {
+              var t = $('#reportContent');
+              
+              // Reset the iframe size before polling its contents so the size is correct.
+              // NOTE: Setting to 0 prevented IE9-Quirks from detecting the correct sizes.
+              t.width(10).height(10);
+              
+              // It's HTML content, so the following is valid
+              var d = $(t[0].contentWindow.document);
+              var w = d.width();
+              var h = d.height();
+              
+              // TODO: HACK: IE8 requires some additional space to not show scrollbars inside
+              t.width(w+20).height(h+20);
               $('#reportPageOutline').width(t.outerWidth());
+              
+              //else if(!isPageStyled()) -> IFrame Height and Width are controlled in #resize, below
             }
-
+            
             this.resize();
-            t.show(); // PRD-4000 Show iframe after resize
+            
+            // PRD-4000 Show iframe after resize
+            this._showReportContent(true);
           }
         }
-      },
+      }, // end view
 
       createRequiredHooks: function(promptPanel) {
-    	
-    	// [PIR-543] - Allow new/refreshed reports to re-attach or override instance functions in the top window object
-    	// Top window functions may become orphaned due to content linking refresh or when a report tab in PUC is closed
-    	/*
-        try{
+        // [PIR-543] - Allow new/refreshed reports to re-attach or override instance functions in the top window object
+        // Top window functions may become orphaned due to content linking refresh or when a report tab in PUC is closed
+        /*
+        try {
           if (window.reportViewer_openUrlInDialog || top.reportViewer_openUrlInDialog) {
             return;
           }
-        }
-        catch(err){
+        } catch(err) {
           return; // [PIR-543] - IE 9.0.5 throws a Permission Denied error
         }
-		*/
+        */
 
         if (!top.mantle_initialized) {
           top.mantle_openTab = function(name, title, url) {
             window.open(url, '_blank');
           }
         }
+        
         if (top.mantle_initialized) {
           top.reportViewer_openUrlInDialog = function(title, url, width, height) {
             top.urlCommand(url, title, true, width, height);
-          }
+          };
         } else {
           top.reportViewer_openUrlInDialog = this.openUrlInDialog.bind(this);
         }
+        
         window.reportViewer_openUrlInDialog = top.reportViewer_openUrlInDialog;
         window.reportViewer_hide = this.hide.bind(this);
-        
-        var localThis = this;
-        
-        if (typeof window.top.addGlassPaneListener !== 'undefined') {
-            window.top.addGlassPaneListener({
 
-    	        glassPaneHidden: function(){
-    	        	localThis.view.show();
-    	        }
-    	    });
+        var localThis = this;
+
+        if (typeof window.top.addGlassPaneListener !== 'undefined') {
+          window.top.addGlassPaneListener({
+            glassPaneHidden: function(){
+              localThis.view.show();
+            }
+          });
         }
-        
       },
 
       openUrlInDialog: function(title, url, width, height) {
@@ -376,37 +450,169 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
         this.view.resize();
       },
 
-      _updateReport: function(promptPanel, renderMode) {
-    	  
-    	// if we are rendering parameters for scheduler UI, never show report
-    	if (inSchedulerDialog) {
-			this.view.showPromptPanel(true);
-			dijit.byId('glassPane').hide();
-	
-			  dojo.addClass('reportContent', 'hidden');
-			  dojo.addClass(dojo.query('.submit-panel')[0], 'hidden');	
-        	  //dojo.addClass('submit-panel', 'hidden');
-        	  dojo.removeClass('promptPanel', 'pentaho-rounded-panel-bottom-lr');
-        	  dojo.removeClass('reportControlPanel', 'pentaho-shadow');
-        	  dojo.removeClass('reportControlPanel', 'pentaho-rounded-panel-bottom-lr');
-			  dojo.addClass('toolbarlinner2', 'hidden');
+      promptReady: function(promptPanel) {
+        if (inSchedulerDialog) {
+          // If we are rendering parameters for the "New Schedule" dialog,
+          // don't show the report or the submit panel, or the pages toolbar
+          this.view.showPromptPanel(true);
 
-			if (typeof window.parameterValidityCallback !== 'undefined') {
-				window.parameterValidityCallback(!promptPanel.paramDefn.promptNeeded);
-			}
-			  
-    		return;
-    	}
-    	  
-		
-        if (promptPanel.paramDefn.promptNeeded) {
-          $('#' + this.htmlObject).attr('src', 'about:blank');
-          dijit.byId('glassPane').hide(); // PRD-3962
-          return; // Don't do anything if we need to prompt
-		}
+          dijit.byId('glassPane').hide();
+          dojo.addClass('reportContent', 'hidden');
+          dojo.addClass(dojo.query('.submit-panel')[0], 'hidden');
+          dojo.addClass('toolbarlinner2', 'hidden');
+
+          dojo.removeClass('promptPanel', 'pentaho-rounded-panel-bottom-lr');
+          dojo.removeClass('reportControlPanel', 'pentaho-shadow');
+          dojo.removeClass('reportControlPanel', 'pentaho-rounded-panel-bottom-lr');
+
+          if (typeof window.parameterValidityCallback !== 'undefined') {
+            var isValid = !promptPanel.paramDefn.promptNeeded;
+            window.parameterValidityCallback(isValid);
+          }
+        }
+      },
+
+      submitReportStart: function() {
+        // Submit button was mouse-downed!
+        
+        // In case that a focusout already issued a "fetchParameterDefinition", and a response is to be received,
+        // we upgrade that request to behave like if a button had been clicked, by setting prompt.mode to 'MANUAL'.
+        // This way, if the user takes longer to release the mouse button,
+        // than the focusout response takes to replace the being clicked button by another one (Dashboards.init recreates everything),
+        // causing the click event no be generated,
+        // the focusout response processing will behave as if it were the response of a click.
+        //
+        // Because Dashboards.processChange ends up calling postChange in a setTimeout...
+        // this call actually gets executed **before** the logic fired by the focusout path,
+        // and fetchParameterDefinition has not been called yet.
+        this.prompt.clicking = true;
+      },
+
+      submitReport: function(promptPanel, keyArgs) {
+        var isInit = keyArgs && keyArgs.isInit;
+        if(!isInit) {
+          if(this.prompt.ignoreNextClickSubmit) {
+            delete this.prompt.ignoreNextClickSubmit;
+            return;
+          }
+
+          this.prompt.mode = 'MANUAL';
+        }
+        
+        // Make sure that layout is initialized
+        this.view._initLayout(promptPanel);
+        
+        try {
+          // If we are rendering parameters for the "New Schedule" dialog,
+          // don't show the report, the submit panel and pages toolbar.
+          if (inSchedulerDialog) {
+            this._submitReportEnded(promptPanel);
+            return;
+          }
+            
+          // Don't do anything if we need to prompt
+          var isValid = !promptPanel.paramDefn.promptNeeded;
+          if (!isValid) {
+            $('#' + this.htmlObject).attr('src', 'about:blank'); // TODO: why htmlObject? Why not this._showReportContent(false)?
+            this._submitReportEnded(promptPanel);
+            return;
+          }
+        
+          this._updateReportContent(promptPanel, keyArgs);
+        
+        } catch(ex) {
+          this._submitReportEnded(promptPanel);
+        }
+      },
+      
+      _updateReportTimeout: -1,
+      
+      _updateReportContent: function(promptPanel, keyArgs) {
+        var me = this;
+        
+        // PRD-3962 - show glass pane on submit, hide when iframe is loaded
+        // Show glass-pane
+        dijit.byId('glassPane').show();
+        
+        // PRD-3962 - remove glass pane after 5 seconds in case iframe onload/onreadystatechange was not detected
+        me._updateReportTimeout = setTimeout(function() {
+          me._submitReportEnded(promptPanel, /*isTimeout*/true);
+        }, 5000);
+        
+        var options = me._buildReportContentOptions(promptPanel);
+        var url = me._buildReportContentUrl(options);
+        
+        // If the iframe isn't hidden here,
+        // when it loads,
+        // the user may see a bit of the new document
+        // but in a different page format..
+        // So, it's just better to hide when "styled" will change.
+        var isHtml = options['output-target'].indexOf('html') != -1;
+        var isProportionalWidth = isHtml && options['htmlProportionalWidth'] == "true";
+        var isReportAlone = dojo.hasClass('toppanel', 'hidden');
+        var styled = !isReportAlone && isHtml && !isProportionalWidth && !this.view.isPentahoMobileEnv();
+        
+        if(me.view.isPageStyled() !== styled) {
+          me.view._showReportContent(false, /*preserveSource*/true);
+        }
+        
+        $('#reportContent').attr("src", url);
+        
+        // Continue when iframe is loaded (called by #_onReportContentLoaded)
+        me._submitLoadCallback = function() {
+          me._isHtmlReport = me.view._isHtmlReport = isHtml;
+          
+          var visible = me.view._calcReportContentVisibility(promptPanel);
+          if(visible) {
+            me.view.updatePageStyling(styled);
+            me.view.resizeIFrame();
+          }
+          
+          me.view._showReportContent(visible);
+          
+          me._submitReportEnded(promptPanel);
+        };
+      },
+      
+      _submitReportEnded: function(promptPanel, isTimeout) {
+        // Clear submit-related control flags
+        delete this.prompt.clicking;
+        if(promptPanel) { delete promptPanel.forceAutoSubmit; }
+        delete this.prompt.ignoreNextClickSubmit;
+        
+        // Awaiting for update report response?
+        if(this._updateReportTimeout >= 0) {
+          clearTimeout(this._updateReportTimeout);
+          this._updateReportTimeout = -1;
+          
+          if(isTimeout) {
+            // This happens, specifically, when the user selects a downloadable output format.
+            // #_onReportContentLoaded callback might not been called.
+            this.view._showReportContent(false, /*preserveSource*/true);
+          }
+          
+          // PRD-3962 - show glass pane on submit, hide when iframe is loaded
+          // Hide glass-pane, if it is visible
+          dijit.byId('glassPane').hide();
+        }
+      },
+      
+      _onReportContentLoaded: function() {
+        var callback = this._submitLoadCallback;
+        if(callback && this.view._hasReportContent()) {
+          delete this._submitLoadCallback;
+          callback.call(this);
+        } else {
+          this.view.resizeIFrame();
+        }
+      },
+      
+      _buildReportContentOptions: function(promptPanel) {
         var options = util.getUrlParameters();
+
         $.extend(options, promptPanel.getParameterValues());
-        options['renderMode'] = renderMode;
+
+        options['renderMode'] = 'REPORT';
 
         // SimpleReportingComponent expects name to be set
         if (options['name'] === undefined) {
@@ -415,92 +621,33 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
 
         // Never send the session back. This is generated by the server.
         delete options['::session'];
-
+        
+        return options;
+      },
+      
+      _buildReportContentUrl: function(options) {
         var url = window.location.href;
         url = url.substring(0, url.lastIndexOf("/")) + "/report?";
+
         var params = [];
         var addParam = function(encodedKey, value) {
           if(value.length > 0) {
             params.push(encodedKey + '=' + encodeURIComponent(value));
           }
-        }
+        };
+
         $.each(options, function(key, value) {
-          if (value === null || typeof value == 'undefined') {
-            return; // continue
-          }
+          if (value == null) { return; } // continue
+
           var encodedKey = encodeURIComponent(key);
           if ($.isArray(value)) {
-            var val = [];
-            $.each(value, function(i, v) {
-              addParam(encodedKey, v);
-            });
+            $.each(value, function(i, v) { addParam(encodedKey, v); });
           } else {
             addParam(encodedKey, value);
           }
         });
 
-        url += params.join("&");
-
-        // Update page styling based on HTML output or not and if we're not scheduling
-        var proportionalWidth = options['htmlProportionalWidth'] == "true";
-        var isHtml = options['output-target'].indexOf('html') != -1;
-        var isSubscribe = renderMode === 'SUBSCRIBE';
-        this.view.updateReportContentVisibility(promptPanel, renderMode)
-        this.view.updatePageStyling(!isSubscribe && isHtml && !proportionalWidth);
-
-        var iframe = $('#reportContent');
-        iframe.attr("src", url);
-
-        if(!this.view.isPentahoMobileEnv()){
-          this.view.showPromptPanel(true); // PRD-4001
-        }
-      },
-
-      submitReport: function(promptPanel) {
-
-        // PRD-3962 - show glass pane on submit, hide when iframe is loaded
-        var gp = dijit.byId('glassPane');
-        gp.show();
-
-        var handle;
-        if(dojo.isIE){
-          handle = dojo.connect(dojo.byId('reportContent'), "onreadystatechange", function(){
-            gp.hide();
-            dojo.disconnect(handle);
-          });
-        }
-        else{
-          handle = dojo.connect(dojo.byId('reportContent'), "onload", function(){
-            gp.hide();
-            dojo.disconnect(handle);
-          });
-        }
-
-        var options = promptPanel.getParameterValues();
-        if(options['output-target']){
-          var isHtml = options['output-target'].indexOf('html') != -1;
-          if(!isHtml){
-            // PRD-3962 - remove glass pane after 5 seconds in case iframe onload/onreadystatechange was not detected
-            setTimeout(function(){
-              dojo.disconnect(handle);
-              gp.hide();
-            }, 5000);
-          }
-        }
-
-        if (!promptPanel.getAutoSubmitSetting()) {
-          // FETCH page info before rendering report
-          prompt.fetchParameterDefinition(promptPanel, function(newParamDefn) {
-            promptPanel.refresh(newParamDefn);
-            this._updateReport(promptPanel, 'REPORT');
-          }.bind(this), 'MANUAL');
-          return;
-        }
-        this._updateReport(promptPanel, 'REPORT');
-      },
-
-      scheduleReport: function(promptPanel) {
-        this._updateReport(promptPanel, 'SUBSCRIBE');
+        return url + params.join("&");
       }
     }
 


### PR DESCRIPTION
PRD-4101: Report having parameter with display type as Text box behaves abnormally when Auto Submit is unchecked.
PRD-4424: Clicking View report twice to generate report in FF
#### ReportViewer
- Removed references to the discontinued ParamDefinition.subscribe property, the schedule method and renderMode='SCHEDULE'.
- Refactored some code blocks
- Also had to change a lot in the code of init/resize/resizeIFrame due to fixes(some were already not working) or regressions on my behalf of other past issues:
  - PRD-4001 - Report Viewer defaults to a close parameter panel.
  - PRD-4102 - Parameter panel is always hidden in reports if auto-submit option in report is set to false
  - PRD-4271 - Changing focus on textboxes' parameters shows white box rectangle before loading report, changing focus to a different box clears report
    - Had to change the way that the report area is made visible/invisible, placing it off-page, to prevent flickers and still let layout occur in every situation
  - BISERVER-6915 - New Report Viewer should not request pagination when auto-submit is set to false
- Removed a few duplicate requests to the server
- Added a lot of comments and JIRA cases annotations
- Depends on CommonUI pull-request for commit https://github.com/webdetails/pentaho-platform-plugin-common-ui/commit/3c87914abb2030aae9ef7d655688f8740bf8c956
- Depends on CDF commit https://github.com/webdetails/cdf/commit/e1dc5878a7337b6ff98c06bd5b0d7dae407434c4
