### PR TITLE
PRD-3833 - Drilldown to another report opens in same tab showing Report Parameter panel of both reports.

### DIFF
--- a/package-res/reportviewer/report.html
+++ b/package-res/reportviewer/report.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html>
 <html xmlns:pho="http:/www.pentaho.com">
 <head>
     <title>Report Web Viewer</title>
@@ -10,7 +10,7 @@
 
     <link rel="stylesheet" type="text/css" href="../../common-ui/resources/web/dojo/dijit/themes/pentaho/pentaho.css"/>
 
-    <script language="javascript" type="text/javascript" src="webcontext.js?context=reporting"></script>
+    <script type="text/javascript" src="webcontext.js?context=reporting"></script>
 
     <link rel="stylesheet" href="../../../content/pentaho-cdf/js/jquery.tooltip.css" type="text/css" />
     <link rel="stylesheet" href="../../../content/pentaho-cdf/js/jquery.jdMenu.css" type="text/css" />
@@ -21,7 +21,18 @@
     <link rel="stylesheet" href="../../../content/common-ui/resources/web/prompting/pentaho-prompting.css" type="text/css" />
     <link rel="stylesheet" href="../../../content/reporting/reportviewer/reportviewer.css" type="text/css" />
     
-    <script language="javascript" type="text/javascript">
+    <script type="text/javascript">
+      // This is required to be able to detect a child-report viewer.
+      // The viewer variable is not available so soon 
+      // because it is created inside a pen.require.
+      var _isReportViewer = true;
+      var _isTopReportViewer = true;
+      try { _isTopReportViewer = ((window.parent === window) || !window.parent._isReportViewer); } catch(ex){ /*XSS*/ }
+      
+      var inMobile = false;
+      try { inMobile = !!window.top.PentahoMobile; } catch(ex) { /*XSS*/ }
+      //	inMobile = true; // For testing mobile case in PC
+      
 	  /**
 	   * This is called when the formatter gwt module has been loaded. We depend on this so we'll load the prompt after 
 	   * the formatter has been loaded.
@@ -35,19 +46,25 @@
 	        });
 	      });
 	    }
-	  }
-	  if (window.top.showLoadingIndicator) {
-	    window.top.showLoadingIndicator();
-	  } else if (window.parent.showLoadingIndicator) {
-	    window.parent.showLoadingIndicator();
-	  }	  
+	  };
+	  
+	  try {
+		  if(window.top.showLoadingIndicator) {
+		    window.top.showLoadingIndicator();
+		  } else if(window.parent.showLoadingIndicator) {
+		    window.parent.showLoadingIndicator();
+		  }
+	  } catch(ex) { /*XSS*/ }
     </script>
     <script type="text/javascript" src="../../../content/common-ui/resources/web/formatter/formatter.nocache.js"></script>
     
-    <script language="javascript" type="text/javascript">
+    <script type="text/javascript">
       // Provide somewhere for cdf/simile/ajax/scripts/json to inject itself into
       var SimileAjax = {};
-
+      
+      var logger, logged;
+      
+      // TODO: Couldn't this be a local variable of the below function??
       var dependencies = [];
       pen.require(['common-ui/util/util'], function(util) {
         // Load the compressed dojo if we're not in debug mode
@@ -87,16 +104,38 @@
 			  // forcing no-op with override
             }
           });
-
+          
+          // Logging must be defined before loading reportviewer
+      	  pen.require(['local', 'reportviewer/reportviewer-logging'], function(local, logging) {
+      	    var options;
+      	    if(_isTopReportViewer) {
+              var qs;
+              try       { qs = window.top.location.search; } 
+              catch(ex) { qs = window.location.search;     } /*XSS*/
+                
+              options = {enabled: !!qs && ("&" + qs.substr(1)).indexOf("&debug=true") >= 0};
+            } else {
+              options = {parent: window.parent.logger};
+            }
+      	    
+      	    logged = logging.create(/*logger id*/window.name, options);
+            logger = logged.logger; // may be null
+            
+            local.define('logger');
+      	  });
+      	  
           // Load and launch the report viewer application
-          pen.require(['local!dojo', 'local!formatter', 'cdf/Dashboards', 'reportviewer/reportviewer', 'reportviewer/reportviewer-prompt'], function(dojo, formatter, dashboards, Viewer, Prompt) {
+          pen.require([
+            'local!dojo', 'local!formatter', 'local!logger', 
+            'cdf/Dashboards', 'reportviewer/reportviewer', 'reportviewer/reportviewer-prompt'
+          ], function(dojo, formatter, local_logger, dashboards, Viewer, Prompt) {
             window.prompt = new Prompt();
             window.viewer = new Viewer(prompt);
             window.prompt.load();
-
-            $(window).resize(function() {
-              viewer.view.resize();
-            });
+			
+            $(window).resize(logged('window.resize', function() {
+              viewer.view.onViewportResize();
+            }));
           });
 
           dojo.require('dojo.parser');
@@ -118,26 +157,29 @@
     </script>	    
   </head>
   
-  <body class="tundra body">
-    <div id="toppanel" class="pentaho-transparent hidden">
-      <div id="toppanelinner" >
-        <div id="toolbarlinner2" class="pentaho-rounded-panel2-shadowed pentaho-padding-sm pentaho-shine pentaho-background">
-          <div id="toolbar" dojoType="dijit.Toolbar" >
-            <div id="pageControl" dojoType="pentaho.common.PageControl" class="dijitInline"></div>
-            <span id="toolbar-parameter-separator" dojoType="dijit.ToolbarSeparator"></span>
-            <div id="toolbar-parameterToggle" dojoType="dijit.form.ToggleButton" iconClass="dijitEditorIcon dijitEditorIconParameters" showLabel="false">Parameters</div>
-          </div>
-        </div>
-        <script type="text/javascript">
-          var inMobile = false;
-          try{
-            inMobile = window.parent && window.parent.PentahoMobile;
-          }catch(e){/*XSS catch*/}
-          if(inMobile){
-            document.getElementById('toolbarlinner2').innerHTML = '<div id="toolbar" style="display: -webkit-box"><div id="toolbar-parameterToggle"  dojoType="dijit.form.ToggleButton">Prompts</div><div style="display: -webkit-box; -webkit-box-flex: 1; box-sizing: border-box; -webkit-box-align: center; -webkit-box-pack: center;"><div id="pageControl" dojoType="pentaho.common.PageControl" class="dijitInline"></div></div><div style="visibility: hidden"  dojoType="dijit.form.ToggleButton">Prompts</div></div>';
-
+  <body class="tundra body contentHidden">
+	<div id="toppanel" class="pentaho-transparent hidden">
+	  <div id="toppanelinner" >
+	    <div id="toolbarlinner2" class="pentaho-rounded-panel2-shadowed pentaho-padding-sm pentaho-shine pentaho-background">
+	      <div id="toolbar" dojoType="dijit.Toolbar">
+	        <div id="pageControl" dojoType="pentaho.common.PageControl" class="dijitInline"></div>
+	        <span id="toolbar-parameter-separator" dojoType="dijit.ToolbarSeparator"></span>
+	        <div id="toolbar-parameterToggle" dojoType="dijit.form.ToggleButton" iconClass="dijitEditorIcon dijitEditorIconParameters" showLabel="false">Parameters</div>
+	      </div>
+	    </div>
+	    <script type="text/javascript">
+          if(inMobile) {
+            document.getElementById('toolbarlinner2').innerHTML = 
+              '<div id="toolbar" style="display: -webkit-box">' + 
+                '<div id="toolbar-parameterToggle" dojoType="dijit.form.ToggleButton">Prompts</div>' + 
+                '<div style="display: -webkit-box; -webkit-box-flex: 1; box-sizing: border-box; -webkit-box-align: center; -webkit-box-pack: center;">' +
+                  '<div id="pageControl" dojoType="pentaho.common.PageControl" class="dijitInline"></div>' + 
+                '</div>' + 
+                '<div style="visibility: hidden" dojoType="dijit.form.ToggleButton">Prompts</div>' + // TODO: What is this? A second button? 
+              '</div>';
           }
-          var inSchedulerDialog = window.location.pathname.indexOf('parameterUi') >= 0;
+          
+          var inSchedulerDialog = window.location.pathname.toLowerCase().indexOf('parameterui') >= 0;
           var getParams = function() { return prompt.panel.getParameterValues(); };
           
           var initSchedulingParams = function(filePath, validParamsCallback) {
@@ -149,21 +191,19 @@
             	this.parameterValidityCallback(false);
       		}
           };
-        </script>
-
-        <div id="reportControlPanel" class="hidden pentaho-rounded-panel-bottom-lr pentaho-shadow">
-          <div id="promptPanel" width="200px" class="pentaho-rounded-panel-bottom-lr"></div>
-        </div>
-      </div>
-    </div>
-    <!-- It's hard to get a 0-height empty div in IE... -->
-    <div id="reportAreaTop" style="visibility:hidden;height:0px;width:0px;margins:0px;paddings:0px;font-size:0px;line-height:0px;position:static;display:block;"></div>
-    <div id="reportArea" class="pentaho-transparent" style="visibility:hidden;" scrollexception="true">
-	  <div id="reportPageOutline">
-	    <iframe id="reportContent" frameborder="0" style="width:100%;"></iframe>
+	    </script>
+	    <div id="reportControlPanel" class="hidden pentaho-rounded-panel-bottom-lr pentaho-shadow">
+	      <div id="promptPanel" class="pentaho-rounded-panel-bottom-lr"></div>
+	    </div>
 	  </div>
 	</div>
-	
+
+	<div id="reportArea" class="pentaho-transparent">
+	  <div id="reportPageOutline">
+        <iframe id="reportContent" frameborder="0"></iframe>
+      </div>
+    </div>
+
     <div id="messageBox" dojoType="pentaho.common.MessageBox" title="" style="width:400px; display:none;">
     </div>
     <div id="glassPane" dojoType="pentaho.common.GlassPane">

--- a/package-res/reportviewer/reportviewer-logging.js
+++ b/package-res/reportviewer/reportviewer-logging.js
@@ -1,0 +1,145 @@
+pen.define(function() {
+  var levelIndentText = "&nbsp;&nbsp;&nbsp;&nbsp;";
+  
+  var S = function(s) { return s == null ? "" : String(s); };
+  var htmlEscape = function(s) { 
+    return S(s).replace('&', '&amp;').replace('<', '&lt;'); // order is relevant 
+  };
+  
+  // Log-decorates a function
+  var logWrap = function (p, f, logger) {
+    if(f.__logwrapper__) { return f; }
+    
+    var g = function() {
+      logger.group(p);
+      var v0 = logger.count();
+      var result, error;
+      try {
+        return (result = f.apply(this, arguments));
+      } catch(ex) {
+        error = ex;
+        logger.raw("$*? " + htmlEscape(ex), null, v0);
+        throw ex;
+      } finally {
+        if(!error && result !== undefined) {
+          logger.raw("&rarr; " + htmlEscape(result), null, v0);
+        }
+        logger.groupEnd(p);
+      }
+    };
+    
+    g.__logwrapper__ = true;
+    
+    return g;
+  };
+  
+  // Create a new logger
+  var createLogger = function(id, options) {
+    if(!options) { options= {}; }
+    if(!id) { id = "unnamed"; }
+    
+    var parent = options.parent;
+    if(parent) { // => enabled
+      return {
+          id:       id,
+          raw:      function(s, lid, v) { parent.raw(s, lid || id, v);   },
+          log:      function(s, lid, v) { parent.log(s, lid || id, v);   },
+          group:    function(s, lid, v) { parent.group(s, lid || id, v); },
+          groupEnd: function(         ) { parent.groupEnd();             },
+          count:    function(         ) { return parent.count();         }
+      };
+    }
+    
+    var enabled = !!options.enabled;
+    if(!enabled) { return null; }
+    
+    // May be null in case popups blocked
+    var logWin = window.open('', options.winname || 'report_viewer_log');
+    if(!logWin) { return null; }
+    
+    var logDoc = logWin.document;
+    
+    // Clear existing content, in case it's not a new window.
+    logDoc.open();
+    logDoc.write('<h1>LOG</h1><table id="logTable"><tbody /></table>');
+    logDoc.close();
+    var logTBody = $(logDoc).find('#logTable > tbody');
+    
+    var levels = [];
+    var counter = 1;
+    var loggerColors = {};
+    var colors = ['green', 'blue', 'red'];
+    var nextColor = 0;
+    var getLoggerColor = function(lid) {
+      return loggerColors[lid] || (loggerColors[lid] = colors[nextColor++ % colors.length]);
+    };
+    
+    var write = function(s, lid, v) {
+      if(lid == null) { lid = id; }
+      var append = v != null && (v === counter);
+      counter++;
+      try {
+        if(append) {
+          $('<span>&nbsp;' + S(s) + '</span>', logDoc)
+            .appendTo(
+              logTBody
+              .children().last()   // last tr
+              .children().last()); // last td
+        } else {
+          $('<tr><td style="color:' + getLoggerColor(lid) + ';">' + lid + '</td>' + 
+                '<td>' + levels.join('') + S(s) + '</td>' + 
+            '</tr>', logDoc)
+            .appendTo(logTBody);
+        }
+      } catch(ex) {
+        alert("[" + lid + "] log - " + ex);
+      }
+    };
+    
+    return {
+      raw:      function(s, lid, v) { write(s, lid, v); },
+      log:      function(s, lid, v) { write("&bull; " + htmlEscape(s), lid, v); },
+      group:    function(s, lid, v) {
+        write("&rsaquo; " + htmlEscape(s), lid, v);
+        levels.push(levelIndentText);
+      },
+      groupEnd: function() { counter++; levels.pop(); },
+      count:    function() { return counter; }
+    };
+  };
+  
+  var createLogged = function(logger) {
+    var logged;
+    if(logger) {
+      logged = function(o, f) {
+        switch(typeof o) {
+          case 'string':   return logWrap(/*name*/o, f, logger);
+          case 'function': return logWrap(/*name*/'anonymous', o, logger);
+        }
+        
+        for(var p in o) {
+          var f = o[p];
+          if(typeof f === 'function') {
+            o[p] = logWrap(p, f, logger);
+          }
+        }
+        return o;
+      };
+    } else {
+      logged = function(o, f) {
+        return (typeof o === 'string') ? f : o; 
+      };
+    }
+    logged.logger = logger;
+    return logged;
+  };
+
+  return {
+    create: function(id, options) {
+      // logger may be null
+      // but logged is always not null
+      var logger = createLogger(id, options);
+      return createLogged(logger);
+    }
+  };
+});

--- a/package-res/reportviewer/reportviewer.css
+++ b/package-res/reportviewer/reportviewer.css
@@ -1,11 +1,33 @@
-html { overflow: hidden;}
+* {
+	overflow: hidden;
+}
+
+html, body {
+	padding: 0px;
+	margin:  0px;
+	border:  0px;
+}
 
 .body {
-    overflow: hidden;
+	position: relative;
 }
 
 .table {
     border: 1px solid #808080;
+}
+
+/* PROMPT PANEL */
+#toppanel {
+	/* ATTENTION: do NOT remove this pixel.
+	   It prevents collapsing of bottom margin of #reportControlPanel
+	   with the margin of #toppanel,
+	   in non-styled mode.
+	   When this happens, 
+	   because $ fails to detect the collapsing, 
+	   the height measure of #toppanel does not account
+	   for the margin of #reportControlPanel.
+	*/
+	padding: 0 0 1px 0;
 }
 
 #reportControlPanel {
@@ -15,56 +37,127 @@ html { overflow: hidden;}
   border: 1px solid rgba(0, 0, 0, 0.59375);
 }
 
-.styled >* #reportControlPanel {
+.nonMobile.styled #reportControlPanel {
   margin: 0px 10px 0px 10px;
+}
+
+.mobile #reportControlPanel {
+  margin: 0 0 10px 0;
 }
 
 div.prompt-panel {
   max-height: 300px;
 }
 
+/* CONTENT AREA */
+
+/* The role of the report area is to show a scroll-bar, 
+   at the right-most position of the report viewer. 
+   Scroll-bar is only shown when .styled.
+   
+   Report area height is always set in code, 
+   so as to fill all the space between the top-panel
+   and the bottom of the document.
+*/
 #reportArea {
-  padding: 0;
-  overflow: hidden;
-  /* Required to be position: relative for IE7 so that the reportPageOutline can be properly scrolled and will not overflow. */
   position: relative;
+  
+  /* size to 100% of parent's width */
+  display:  block;
+  
+  /* Ensure that child reportPageOutline is shown centered */
+  text-align: center;
+  
+  padding: 0;
+}
+
+/* Report content is hidden by 
+   absolutely positioning it off-page 
+   to avoid flicker when size-polling.
+   
+   Also, cannot hide (visibility/display) a parent of 
+   the iframe where a pdf is to be shown, or the pdf does not render (IE?).
+   
+   PRD-4271 Don't show white box rectangle...
+   PRD-4018, PRD-4034 FF & IE8 does not resize properly when iframe is hidden.
+*/
+.contentHidden #reportArea {
+	position: absolute;
+	left: -100000;
+    top:  -100000;
 }
 
 .styled #reportArea {
-  padding: 8px 0 8px 0;
+  padding: 8px 0;
+}
+
+.topViewer.styled #reportArea {
   overflow: auto;
 }
 
-.dj_ie7 #reportArea {
- top: 8px;
-}
-
 #reportPageOutline {
-  position: relative;
-  margin-left: auto;
-  margin-right: auto;
-  width: 700px;
+  /* When unstyled, both width and height should be that of the parent */
+  display: block;
+  height:  100%;
 }
 
-#reportPageSpacer {
-  height: 12px;
+.styled #reportPageOutline {
+  /* Make the div horizontally fit to its content (inline-block).
+  
+     Being an inline element and having parent reportArea, 
+     reportArea's "text-align:center" will center it.
+   */
+  display: inline-block;
+  height:  auto;
 }
 
 #reportContent {
+  display: block;
   background-color: #ffffff;
-}	
+  width:  100%;
+  height: 100%;
+}
 
-.styled >* #reportContent {
+.leafViewer.nonStyled #reportContent {
+  /* Enables scrolling for the Text format (output-target: pageable/text).
+  	 In PDFs, scrolling is always provided by the pdf viewer, 
+  	 according to the iframe size,
+  	 irrespective of our scrolling settings.
+  */
+  overflow: auto;
+}
+
+.styled #reportContent {
+  /* In this case,
+     both width and height are set by code, 
+     so that the iframe fits the content's size
+  */
   padding: 10px 10px 10px 2px;
   border: black 1px solid;
-  height: 500px;
-  /* Initial width, will be updated by onresize() */
-  width: 686px; /* 700 - (padding + border) */
+  overflow: inherit;
+}
+
+.styled.parentViewer #reportContent {
+	padding: 0;
 }
 
 .hidden {
-	display: none !important;
+  display: none !important;
 }
+
+/* Debugging styles for report */
+.debug #reportArea {
+	border: solid 3px green;
+}
+
+.debug #reportPageOutline {
+	border: solid 1px red;
+}
+
+.debug #reportContent {
+	border: solid 3px yellow;
+}
+
 
 .dialog-content {
   height: auto;
@@ -230,17 +323,3 @@ div.prompt-panel {
     padding-right: 8px; 
     padding-bottom: 8px;
 }
-
-/* Debugging styles for report area
-#reportArea {
-	border: solid 3px green;
-}
-
-#reportPageOutline {
-	border: solid 3px red;
-}
-
-#reportContent {
-	border: solid 3px yellow;
-}
- */


### PR DESCRIPTION
Apart from the following commit change log, there's one thing I'm not sure to be doing right. I added a new file "reportviewer-logging.js" and it is being requested using pen.require in reportviewer.html. Anyway, there, there is complex logic for loading compressed vs uncompressed code. I have not registered the new file in reportviewer-app.js or reportviewer-main-module.js, because, honestly, I don't quite understand how this works yet.
##### Commit change log
- Removed some unnecessary viewer.view.resize calls.
- Removed some unnecessary viewer.view._showReportContent calls.
- Added logging to enable debugging in iOS/Safari.
  Inspecting url "debug=true" to activate logging.
  Added new file to support this: reportviewer-logging.js.
- Changed most JavaScript calls to set element Styles to setting Classes.
  Added new classes to body to support this: contentHidden, topViewer, leafViewer, parentViewer, mobile, nonMobile, nonStyled and debug.
  All styling is now done in CSS.
- Fixed a bug in which the prompt panel would be unavailable instead of collapsed by default.
- Renamed viewer.view.resize -> viewer.view.resizeContentArea and of viewer.view.resizeIFrame -> viewer.view.resize (full resize, includes the former)
- Renamed viewer.view.updatePageStyling -> viewer.view.setPageStyled
- Fixed the iOS scrolling hack (in viewer.view._resizeMobileHtmlReportHandlesScrolling) 
  being incorrectly applied to a child report viewer, messing the layout.
  Now checks if the child report is a report engine report by looking at the meta[@generator] attribute.
- Added a check that prevents styled content to be too small, by assuming a default width of 2/3 of viewport.width.
- Added detection of "unrequested" content iframe loads. This can happen because of links in the html content (viewer.view._updatedIFrameSrc).
- Removed the local viewer.view.isPentahoMobileEnv() predicate and started using the global "inMobile" variable, just like with other similar global indicators.
- When the content is a child report viewer, changes to non-styled.
- Fixed styled report not being centered in IE8.
  Now using #reportPageOutline {display:inline-block} and #reportArea{text-align:center} instead of #reportPageOutline{ margin-left/right:auto }.
- Removed unnecessary language="javascript" attributes from script tags.
- Added global variables _isReportViewer and _isTopReportViewer to facilitate testing for child report viewers.
