### PR TITLE
Small fixes to the report viewer

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -29,6 +29,9 @@ pen.define(['common-ui/util/util', 'common-ui/util/formatting'], function(util, 
         panel.ready = this.ready.bind(this);
 
         panel.getParameterDefinition = function(promptPanel, callback) {
+          // Show glass pane when updating the prompt.
+          dijit.byId('glassPane').show();
+
           // promptPanel === panel
           this.fetchParameterDefinition(promptPanel, callback, 'USERINPUT');
         }.bind(this);
@@ -57,7 +60,9 @@ pen.define(['common-ui/util/util', 'common-ui/util/formatting'], function(util, 
         this.panel.init();
       },
 
-      ready: function(promptPanel) {},
+      ready: function(promptPanel) {
+        dijit.byId('glassPane').hide();
+      },
 
       /**
        * Called by the prompt-panel component when the CDE components have been updated.
@@ -109,7 +114,7 @@ pen.define(['common-ui/util/util', 'common-ui/util/formatting'], function(util, 
        * @return true if the content is the login page.
        */
       isSessionTimeoutResponse: function(content) {
-        if(content.indexOf('j_spring_security_check') != -1) {
+        if(String(content).indexOf('j_spring_security_check') != -1) {
           // looks like we have the login page returned to us
           return true;
         }

--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -57,7 +57,8 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
           dojo.connect(dojo.byId('reportContent'), "load", onFrameLoaded);
         }
         
-        this.prompt.ready       = this.view.promptReady.bind(this.view);
+        var basePromptReady = this.prompt.ready.bind(this.prompt);
+        this.prompt.ready       = this.view.promptReady.bind(this.view, basePromptReady);
         this.prompt.submit      = this.submitReport.bind(this);
         this.prompt.submitStart = this.submitReportStart.bind(this);
         
@@ -112,10 +113,6 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
           }
         },
 
-        updateReportContentVisibility: function(promptPanel) {
-          this._showReportContent(this._calcReportContentVisibility(promptPanel));
-        },
-        
         _showReportContent: function(visible, preserveSource) {
           // Force not to show a blank iframe
           var hasContent = this._hasReportContent();
@@ -214,7 +211,10 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
         },
                 
         // Called by PromptPanel#postExecution (soon after initPrompt)
-        promptReady: function(promptPanel) {
+        promptReady: function(basePromptReady, promptPanel) {
+
+          basePromptReady();
+
           if (inSchedulerDialog) {
             // If we are rendering parameters for the "New Schedule" dialog,
             // don't show the report or the submit panel, or the pages toolbar
@@ -610,7 +610,9 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
         var isProportionalWidth = isHtml && options['htmlProportionalWidth'] == "true";
         var isReportAlone = dojo.hasClass('toppanel', 'hidden');
         
-        var styled = _isTopReportViewer && !isReportAlone && isHtml && !isProportionalWidth && !inMobile;
+        var styled = _isTopReportViewer && !isReportAlone && 
+                     isHtml && !isProportionalWidth && 
+                     !inMobile;
         
         // If the new output format causes a pageStyle change, 
         // and we don't hide the iframe "now",


### PR DESCRIPTION
PRD-3687 - Reports with multi-select list refreshes for every single select.
- Show glass-pane as soon as the prompt starts refreshing to avoid that the user types stuff that will get replaced.
- Fix a "no such method exists" error in isSessionTimeoutResponse
