### PR TITLE
[BISERVER-9770] reports created in PRD have started to include a new pro...

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/connection/PentahoCubeFileProvider.java
+++ b/src/org/pentaho/reporting/platform/plugin/connection/PentahoCubeFileProvider.java
@@ -37,11 +37,20 @@ public class PentahoCubeFileProvider extends DefaultCubeFileProvider
   {
     setMondrianCubeFile(definedFile);
   }
+  
+  public PentahoCubeFileProvider(final String definedFile, final String definedConnectionName)
+  {
+    setMondrianCubeFile(definedFile);
+    setCubeConnectionName(definedConnectionName);
+  }
 
   public String getCubeFile(final ResourceManager resourceManager,
                             final ResourceKey contextKey) throws ReportDataFactoryException
   {
-    final String superDef = getMondrianCubeFile();
+    // new cube file read method: 
+    // 1st - get new property mondrian cubeConnectionName
+    // 2nd - if cubeConnectionName is null, get default cubeFile property
+    final String superDef = getCubeConnectionName() != null ? getCubeConnectionName() : getMondrianCubeFile();
     if (superDef == null)
     {
       throw new ReportDataFactoryException(Messages.getInstance().getString("ReportPlugin.noSchemaDefined")); //$NON-NLS-1$

--- a/src/org/pentaho/reporting/platform/plugin/connection/PentahoCubeFileProviderReadHandler.java
+++ b/src/org/pentaho/reporting/platform/plugin/connection/PentahoCubeFileProviderReadHandler.java
@@ -28,6 +28,6 @@ public class PentahoCubeFileProviderReadHandler extends DefaultCubeFileProviderR
 
   public CubeFileProvider getProvider()
   {
-    return new PentahoCubeFileProvider(getPath());
+    return new PentahoCubeFileProvider(getPath(), getCubeConnectionName());
   }
 }


### PR DESCRIPTION
...perty (cube-connection-name); biserver 5.0 will read the catalog name from this new property; if the mapped property is null, use the default cube-file-name property
