### PR TITLE
[PRD-4835] moved mondrian connection provider declaration line from here...

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/configuration.properties
+++ b/src/org/pentaho/reporting/platform/plugin/configuration.properties
@@ -15,7 +15,6 @@
 # Copyright (c) 2005-2011 Pentaho Corporation.  All rights reserved.
 #
 
-org.pentaho.reporting.engine.classic.extensions.datasources.mondrian.MondrianConnectionProvider=org.pentaho.reporting.platform.plugin.connection.PentahoMondrianConnectionProvider
 
 org.pentaho.reporting.engine.classic.core.cache.DataCache=org.pentaho.reporting.platform.plugin.cache.PentahoDataCache
 org.pentaho.reporting.platform.plugin.cache.PentahoDataCache.CachableRowLimit=10000


### PR DESCRIPTION
... to pentaho-platform#assembly/package-res/biserver/tomcat/webapps/pentaho/WEB-INF/classes/classic-engine.properties so that the declaration of a customMondrianConnectionProvider can be made without any changes to pentaho-platform-plugin-reporting jar
