### PR TITLE
Fix for BISERVER-10605  When a PRPT has 2 or more Mandatory Prompts Without Default Values BI Server Prevents You From Entering 2nd Prompt 

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -82,11 +82,7 @@ pen.define(['common-ui/util/util', 'reportviewer/reportviewer-formatting'], func
       },
 
       ready: function(promptPanel) {
-        if(this.mode === 'USERINPUT' && 
-           !promptPanel.forceAutoSubmit && 
-           !promptPanel.autoSubmit) {
-          dijit.byId('glassPane').hide();
-        }
+        dijit.byId('glassPane').hide();
       },
 
       /**


### PR DESCRIPTION
Fix for BISERVER-10605  When a PRPT has 2 or more Mandatory Prompts Without Default Values BI Server Prevents You From Entering 2nd Prompt 
