### PR TITLE
[PRD-5086] - When auto-submit is off, the report parameter/prompt panel flashes/glass pane appears.

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -65,9 +65,6 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
         //    PromptPanel._ready ->
         //    
         panel.getParameterDefinition = function(promptPanel, callback) {
-          // Show glass pane when updating the prompt.
-          registry.byId('glassPane').show();
-
           // promptPanel === panel
           this.fetchParameterDefinition(promptPanel, callback, /*promptMode*/'USERINPUT');
         }.bind(this);
@@ -98,8 +95,17 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
         this.panel.init();
       },
 
-      ready: function(promptPanel) {
+      showGlassPane: function() {
+        // Show glass pane when updating the prompt.
+        registry.byId('glassPane').show();
+      },
+
+      hideGlassPane: function() {
         registry.byId('glassPane').hide();
+      },
+
+      ready: function(promptPanel) {
+        this.hideGlassPane();
       },
 
       /**
@@ -214,14 +220,19 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
        * The callback signature is:
        * <pre>void function(newParamDef)</pre>
        *  and is called in the context of the report viewer prompt instance.
-       * @param {string} [promptMode='MANUAL'] the prompt mode to request from server: 
-       *  {INITIAL, MANUAL, USERINPUT}.
+       * @param {string} [promptMode='MANUAL'] the prompt mode to request from server:
+       *  x INITIAL   - first time
+       *  x MANUAL    - user pressed the submit button (or, when autosubmit, after INITIAL fetch)
+       *  x USERINPUT - due to a change + auto-submit
+       *
        * If not provided, 'MANUAL' will be used.
        */
       fetchParameterDefinition: function(promptPanel, callback, promptMode) {
         var me = this;
         
         var fetchParamDefId = ++me._fetchParamDefId;
+
+        me.showGlassPane();
 
         if(!promptMode) { promptMode = 'MANUAL'; }
 

--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -76,11 +76,16 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
           on(dom.byId('reportContent'),  "load", lang.hitch( onFrameLoaded));
         }
 
-        var basePromptReady = this.prompt.ready.bind(this.prompt);
-        this.prompt.ready       = this.view.promptReady.bind(this.view,  basePromptReady);
-        this.prompt.submit      = this.submitReport.bind(this);
-        this.prompt.submitStart = this.submitReportStart.bind(this);
-        
+        var basePromptReady   = this.prompt.ready.bind(this.prompt);
+        var baseShowGlassPane = this.prompt.showGlassPane.bind(this.prompt);
+        var baseHideGlassPane = this.prompt.hideGlassPane.bind(this.prompt);
+
+        this.prompt.ready         = this.view.promptReady  .bind(this.view,  basePromptReady);
+        this.prompt.showGlassPane = this.view.showGlassPane.bind(this.view,  baseShowGlassPane);
+        this.prompt.hideGlassPane = this.view.hideGlassPane.bind(this.view,  baseHideGlassPane);
+        this.prompt.submit        = this.submitReport.bind(this);
+        this.prompt.submitStart   = this.submitReportStart.bind(this);
+
         $('body')
           .addClass(_isTopReportViewer ? 'topViewer leafViewer' : 'leafViewer')
           .addClass(inMobile ? 'mobile' : 'nonMobile');
@@ -248,7 +253,23 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
             elem = elem.parentNode;
           }
         },
-                
+        
+        showGlassPane: function(base) {
+          $("#glasspane")
+            .css("background", v.reportContentUpdating() ? "" : "transparent");
+          
+          base();
+        },
+
+        hideGlassPane: function(base) {
+          if(!v.reportContentUpdating()) {
+            base();
+          }
+
+          // Activate bg.
+          $("#glasspane").css("background", "");
+        },
+
         // Called by PromptPanel#postExecution (soon after initPrompt)
         promptReady: function(basePromptReady, promptPanel) {
 
@@ -648,13 +669,13 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
       _updatedIFrameSrc: false,
       _updateReportTimeout: -1,
       
+      reportContentUpdating: function() {
+        return this._updateReportTimeout >= 0;
+      },
+
       _updateReportContent: function(promptPanel, keyArgs) {
         var me = this;
 
-        // PRD-3962 - show glass pane on submit, hide when iframe is loaded
-        // Show glass-pane
-        registry.byId('glassPane').show();
-        
         // When !AutoSubmit, a renderMode=XML call has not been done yet,
         //  and must be done now so that the page controls have enough info.
         if(!promptPanel.getAutoSubmitSetting()) {
@@ -679,6 +700,12 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
         me._updateReportTimeout = setTimeout(logged('updateReportTimeout', function() {
           me._submitReportEnded(promptPanel, /*isTimeout*/true);
         }), 5000);
+
+        // PRD-3962 - show glass pane on submit, hide when iframe is loaded.
+        // Must be done AFTER _updateReportTimeout has been set, cause it's used to know
+        // that the report content is being updated.
+        me.prompt.showGlassPane();
+
         var options = me._buildReportContentOptions(promptPanel);
         var url = me._buildReportContentUrl(options);
         var outputFormat = options['output-target'];
@@ -744,7 +771,7 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
           
           // PRD-3962 - show glass pane on submit, hide when iframe is loaded
           // Hide glass-pane, if it is visible
-          registry.byId('glassPane').hide();
+          this.prompt.hideGlassPane();
         }
       },
       


### PR DESCRIPTION
Made changes so that the glass pane is only shown with a dark background when the report is being updated (this is the most time-taking process).
When the glass pane is shown, but only the prompt is being refreshed, it is shown transparent, achieving a less disruptive user experience.

The incremental recreation of each of the prompt's CDF controls still significantly disrupts the user experience. It looks like a slide-down effect.

Summarising, two changes were made:
1. replaced all explicit calls to show/hide the glass pane's dojo element with calls to central functions having the same code; this change is conservative of the original behaviour &mdash; a refactoring;
2. then, a behaviour changing change: the new show/hide methods add logic that additionally controls the glass pane's transparency.

Detailing the changes:
- In **reportviewer-prompt.js**
  - Created two methods in the report-viewer prompt showGlassPane and hideGlassPane whose implementation calls show/hide on the dojo element.
  - Replaced all existing calls to show/hide the dojo element with calls to showGlassPane and hideGlassPane.
  - Moved the call to `showGlassPane` in `getParameterDefinition` to `fetchParameterDefinition`. 
    This location is more central: it accounts for other scenarios where `fetchParameterDefinition` is being called directly (in _reportViewer.js_), and thus required additional explicit calls to `showGlassPane`.
- In **reportviewer.js**
  - In the same spirit of other existing code, the prompt's default `showGlassPane` and `hideGlassPane` implementations are overridden with view-specific implementations. These use details only known by the view (whether the report content is loading as well or not) to control the transparency of the glass pane, when showing/hiding.
  - A new method was added, `reportContentUpdating`, which uses the already existing `_updateReportTimeout` variable &mdash; no new state flags were added.
  - Taking advantage that `fetchParameterDefinition` now already calls `showGlassPane`, the existing call in `_updateReportContent` can be moved to the only branch of its code which doesn't call it yet: the `_updateReportContentCore` method. It is placed right after the update to `_updateReportTimeout` variable, so that `showGlassPane` can properly control the glass pane's transparency.

I tested these changes with a variety of reports in report viewer, using Chrome/MacOS and Safari/iPad.
Additional execution contexts still need to be tested:
- Scheduling
- Dashboards
- Interactive Reporting

@mdamour1976, @pamval, @dkincade please comment/review.
