### PR TITLE
[PRD-5097] Previous/Next/Current page controls don't work. First page is always returned.

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -866,7 +866,7 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
 
         var params = [];
         var addParam = function(encodedKey, value) {
-          if(value.length > 0) {
+          if(value) {
             params.push(encodedKey + '=' + encodeURIComponent(value));
           }
         };


### PR DESCRIPTION
Fix required due to the changes for the following case:

http://jira.pentaho.com/browse/PIR-920
https://github.com/pentaho/pentaho-platform-plugin-common-ui/commit/07e8f8add99254e12be6e032a4219839c022e83c
