### PR TITLE
SP-1375 - BISERVER-11863 - Spaces in text box options are replaced by  &...

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -233,6 +233,15 @@ define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/uti
           this._layoutInited = false;
           basePanelInit.call(promptPanel, noAutoAutoSubmit);
           this._initLayout(promptPanel);
+          
+          $.widget( "ui.autocomplete", $.ui.autocomplete, {
+            _renderItem: function( ul, item) {
+              return $( "<li></li>" )
+                .data( "item.autocomplete", item )
+                .append( $( "<a></a>" ).html( item.label ) )
+                .appendTo( ul );
+            },
+          });
         },
 
         _hideToolbarPromptControls: function() {


### PR DESCRIPTION
...#x20; in PUC on PRD report

What was done:
1) extended JQUERY

original jQury method uses text which does not encode decoded symbols and uses them as is.
The fix is done in report viewer, so it should affect reportviewer only
