### PR TITLE
BACKLOG-347 - CLONE - QuerylessDataFactory declares invalid metadata in ...

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/datasources/QuerylessDataFactoryBundle.properties
+++ b/src/org/pentaho/reporting/platform/plugin/datasources/QuerylessDataFactoryBundle.properties
@@ -1,0 +1,22 @@
+#
+# This program is free software; you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+# Foundation.
+#
+# You should have received a copy of the GNU Lesser General Public License along with this
+# program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+# or from the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Lesser General Public License for more details.
+#
+# Copyright (c) 2005-2011 Pentaho Corporation. All rights reserved.
+#
+display-name=Metadata (Designtime)
+grouping=Metadata
+grouping.ordinal=200
+ordinal=20
+description=
+deprecated=

--- a/src/org/pentaho/reporting/platform/plugin/datasources/meta-datafactory.xml
+++ b/src/org/pentaho/reporting/platform/plugin/datasources/meta-datafactory.xml
@@ -1,8 +1,8 @@
 <meta-data xmlns="http://reporting.pentaho.org/namespaces/engine/classic/metadata/1.0">
 
   <data-factory name="org.pentaho.reporting.platform.plugin.datasources.QuerylessDataFactory"
-                bundle-name="org.pentaho.reporting.engine.classic.extensions.datasources.pmd.metadata"
-                metadata-source="true" freeform-query="false" expert="true" experimental="true"
+                bundle-name="org.pentaho.reporting.platform.plugin.datasources.QuerylessDataFactoryBundle"
+                metadata-source="true" freeform-query="false" expert="true" experimental="false" hidden="true"
                 impl="org.pentaho.reporting.engine.classic.extensions.datasources.pmd.PmdDataFactoryCore"/>
 
 </meta-data>


### PR DESCRIPTION
...BI-server reporting plugin

What was done:
1) added messahe properties file
2) changed configuration to use the file
