### PR TITLE
[CDF-271] - Upgrade jquery version on CDF

### DIFF
--- a/package-res/reportviewer/report.html
+++ b/package-res/reportviewer/report.html
@@ -12,7 +12,6 @@
 
   <script type="text/javascript" src="webcontext.js?context=reporting"></script>
 
-  <link rel="stylesheet" href="../../../content/pentaho-cdf/js/jquery.tooltip.css" type="text/css" />
   <link rel="stylesheet" href="../../../content/pentaho-cdf/js/jquery.jdMenu.css" type="text/css" />
   <link rel="stylesheet" href="../../../content/pentaho-cdf/js/jquery.jdMenu.slate.css" type="text/css" />
   <link rel="stylesheet" href="../../../content/pentaho-cdf/js/jquery-impromptu.css" type="text/css" />

--- a/package-res/reportviewer/reportviewer-main-module.js
+++ b/package-res/reportviewer/reportviewer-main-module.js
@@ -15,12 +15,11 @@
  * Copyright (c) 2002-2013 Pentaho Corporation..  All rights reserved.
  */
 define(["cdf/jquery",
-  "cdf/jquery-impromptu.3.1",
+  "cdf/jquery-impromptu",
   "cdf/jquery.ui",
   "cdf/jquery.bgiframe",
   "cdf/jquery.jdMenu",
   "cdf/jquery.positionBy",
-  "cdf/jquery.tooltip",
   "cdf/jquery.blockUI",
   "cdf/jquery.eventstack",
   "cdf/Base",


### PR DESCRIPTION
```
- Updated paths to CDF libs, jquery.tooltip is now bundled in jquery.ui and jquery-impromptu.3.1 was renamed to jquery-impromptu (version 5).
```
