### PR TITLE
[SP-1295][PRD-5086] - When auto-submit is off, the report parameter/prom...

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -49,9 +49,6 @@ pen.define(['common-ui/util/util', 'common-ui/util/formatting'], function(util, 
         //    PromptPanel._ready ->
         //    
         panel.getParameterDefinition = function(promptPanel, callback) {
-          // Show glass pane when updating the prompt.
-          dijit.byId('glassPane').show();
-
           // promptPanel === panel
           this.fetchParameterDefinition(promptPanel, callback, /*promptMode*/'USERINPUT');
         }.bind(this);
@@ -80,8 +77,17 @@ pen.define(['common-ui/util/util', 'common-ui/util/formatting'], function(util, 
         this.panel.init();
       },
 
-      ready: function(promptPanel) {
+      showGlassPane: function() {
+        // Show glass pane when updating the prompt.
+        dijit.byId('glassPane').show();
+      },
+
+      hideGlassPane: function() {
         dijit.byId('glassPane').hide();
+      },
+
+      ready: function(promptPanel) {
+        this.hideGlassPane();
       },
 
       /**
@@ -187,14 +193,19 @@ pen.define(['common-ui/util/util', 'common-ui/util/formatting'], function(util, 
        * The callback signature is:
        * <pre>void function(newParamDef)</pre>
        *  and is called in the context of the report viewer prompt instance.
-       * @param {string} [promptMode='MANUAL'] the prompt mode to request from server: 
-       *  {INITIAL, MANUAL, USERINPUT}.
+       * @param {string} [promptMode='MANUAL'] the prompt mode to request from server:
+       *  x INITIAL   - first time
+       *  x MANUAL    - user pressed the submit button (or, when autosubmit, after INITIAL fetch)
+       *  x USERINPUT - due to a change + auto-submit
+       *
        * If not provided, 'MANUAL' will be used.
        */
       fetchParameterDefinition: function(promptPanel, callback, promptMode) {
         var me = this;
         
         var fetchParamDefId = ++me._fetchParamDefId;
+
+        me.showGlassPane();
 
         if(!promptMode) { promptMode = 'MANUAL'; }
 

--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -57,11 +57,16 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
           dojo.connect(dojo.byId('reportContent'), "load", onFrameLoaded);
         }
         
-        var basePromptReady = this.prompt.ready.bind(this.prompt);
-        this.prompt.ready       = this.view.promptReady.bind(this.view, basePromptReady);
-        this.prompt.submit      = this.submitReport.bind(this);
-        this.prompt.submitStart = this.submitReportStart.bind(this);
-        
+        var basePromptReady   = this.prompt.ready.bind(this.prompt);
+        var baseShowGlassPane = this.prompt.showGlassPane.bind(this.prompt);
+        var baseHideGlassPane = this.prompt.hideGlassPane.bind(this.prompt);
+
+        this.prompt.ready         = this.view.promptReady.bind(this.view,  basePromptReady);
+        this.prompt.showGlassPane = this.view.showGlassPane.bind(this.view,  baseShowGlassPane);
+        this.prompt.hideGlassPane = this.view.hideGlassPane.bind(this.view,  baseHideGlassPane);
+        this.prompt.submit        = this.submitReport.bind(this);
+        this.prompt.submitStart   = this.submitReportStart.bind(this);
+
         $('body')
           .addClass(_isTopReportViewer ? 'topViewer leafViewer' : 'leafViewer')
           .addClass(inMobile ? 'mobile' : 'nonMobile');
@@ -223,7 +228,23 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
             elem = elem.parentNode;
           }
         },
-                
+        
+        showGlassPane: function(base) {
+          $("#glasspane")
+            .css("background", v.reportContentUpdating() ? "" : "transparent");
+          
+          base();
+        },
+
+        hideGlassPane: function(base) {
+          if(!v.reportContentUpdating()) {
+            base();
+          }
+
+          // Activate bg.
+          $("#glasspane").css("background", "");
+        },
+
         // Called by PromptPanel#postExecution (soon after initPrompt)
         promptReady: function(basePromptReady, promptPanel) {
 
@@ -605,13 +626,13 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
       _updatedIFrameSrc: false,
       _updateReportTimeout: -1,
       
+      reportContentUpdating: function() {
+        return this._updateReportTimeout >= 0;
+      },
+
       _updateReportContent: function(promptPanel, keyArgs) {
         var me = this;
 
-        // PRD-3962 - show glass pane on submit, hide when iframe is loaded
-        // Show glass-pane
-        dijit.byId('glassPane').show();
-        
         // When !AutoSubmit, a renderMode=XML call has not been done yet,
         //  and must be done now so that the page controls have enough info.
         if(!promptPanel.getAutoSubmitSetting()) {
@@ -636,6 +657,12 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
         me._updateReportTimeout = setTimeout(logged('updateReportTimeout', function() {
           me._submitReportEnded(promptPanel, /*isTimeout*/true);
         }), 5000);
+
+        // PRD-3962 - show glass pane on submit, hide when iframe is loaded.
+        // Must be done AFTER _updateReportTimeout has been set, cause it's used to know
+        // that the report content is being updated.
+        me.prompt.showGlassPane();
+
         var options = me._buildReportContentOptions(promptPanel);
         var url = me._buildReportContentUrl(options);
         var outputFormat = options['output-target'];
@@ -701,7 +728,7 @@ pen.define(['common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui
           
           // PRD-3962 - show glass pane on submit, hide when iframe is loaded
           // Hide glass-pane, if it is visible
-          dijit.byId('glassPane').hide();
+          this.prompt.hideGlassPane();
         }
       },
       


### PR DESCRIPTION
...pt panel flashes/glass pane appears.

Made changes so that the glass pane is only shown with a dark background when the report is being updated (this is the most time-taking process).
When the glass pane is shown, but only the prompt is being refreshed, it is shown transparent, achieving a less disruptive user experience.

The incremental recreation of each of the prompt's CDF controls still significantly disrupts the user experience. It looks like a slide-in effect.

* Summarising, I made two changes:
** replaced all explicit calls to show/hide the glass pane's dojo element with calls to central functions having the same code; this change is conservative of the original behaviour - a refactoring;
** then (a behaviour changing change), the new show/hide methods add logic that additionally controls the glass pane's transparency.

Detailing the changes:
* In reportviewer-prompt.js
** Created two methods in the report-viewer prompt showGlassPane and hideGlassPane whose implementation calls show/hide on the dojo element.
** Replaced all existing calls to show/hide the dojo element with calls to showGlassPane and hideGlassPane.
** Moved the call to showGlassPane in getParameterDefinition to fetchParameterDefinition.
*** This location is more central: it accounts for other scenarios where fetchParameterDefinition is being called directly (in reportViewer.js), and thus required additional explicit calls to showGlassPane.
* In reportviewer.js
** In the same spirit of other existing code, the default prompt showGlassPane and hideGlassPane implementations are overridden with view-specific implementations. These implementations use details only known by the view (whether the report content is loading as well or not) to control the transparency of the glass pane, when showing/hiding.
* A new method was added, "reportContentUpdating", which uses the already existing "_updateReportTimeout" variable.
* Taking advantage that fetchParameterDefinition already calls showGlassPane, the existing call in _updateReportContent can be moved to the only branch of code which doesn't issue it: the _updateReportContentCore method. It is placed right after the update to "_updateReportTimeout" variable, so that showGlassPane can know that the glass pane must not be transparent.

Conflicts:
	package-res/reportviewer/reportviewer-prompt.js
	package-res/reportviewer/reportviewer.js