### PR TITLE
[BACKLOG-3310] - (Using BISERVER-6.0-SNAPSHOT) Error opening Interaive report

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/ParameterContentGenerator.java
+++ b/src/org/pentaho/reporting/platform/plugin/ParameterContentGenerator.java
@@ -107,10 +107,6 @@ public class ParameterContentGenerator extends SimpleContentGenerator {
    * @return IParameterProvider the provider of parameters
    */
   public IParameterProvider getRequestParameters() {
-    if ( requestParameters != null ) {
-      return requestParameters;
-    }
-
     if ( parameterProviders == null ) {
       return new SimpleParameterProvider();
     }


### PR DESCRIPTION

The content generator instances were hanging onto stale versions of member variables (from previous executions) and the incorrect information was being used (like request parameters and report definitions) that did not apply.