### PR TITLE
[BACKLOG-4066] Fix using Dashboards object

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -24,7 +24,7 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
       mode: 'INITIAL',
 
       load: function() {
-        pentaho.common.Messages.addUrlBundle('reportviewer', CONTEXT_PATH+'i18n?plugin=reporting&name=reportviewer/messages/messages');
+        Messages.addUrlBundle('reportviewer', CONTEXT_PATH+'i18n?plugin=reporting&name=reportviewer/messages/messages');
       },
 
       /**
@@ -76,7 +76,7 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
         panel.createFormatter = ReportFormatUtil.createFormatter.bind(ReportFormatUtil);
 
         // Provide our own i18n function
-        panel.getString = pentaho.common.Messages.getString;
+        panel.getString = Messages.getString;
 
         this.initPromptPanel();
 
@@ -198,9 +198,9 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
           window.parent.authenticate(callback);
         } else {
           this.showMessageBox(
-            pentaho.common.Messages.getString('SessionExpiredComment'),
-            pentaho.common.Messages.getString('SessionExpired'),
-            pentaho.common.Messages.getString('OK'),
+            Messages.getString('SessionExpiredComment'),
+            Messages.getString('SessionExpired'),
+            Messages.getString('OK'),
             undefined,
             undefined,
             undefined,
@@ -359,12 +359,14 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
           messageBox.setButtons([]);
         } else {
           var closeFunc = function() {
-            //Dashboards.hideProgressIndicator();
+            if (this.panel) {
+              this.panel.dashboard.hideProgressIndicator();
+            }
             messageBox.hide.call(messageBox);
           }
 
           if(!button1Text) {
-            button1Text = pentaho.common.Messages.getString('OK');
+            button1Text = Messages.getString('OK');
           }
           if(!button1Callback) {
             button1Callback = closeFunc;
@@ -385,7 +387,9 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
             messageBox.setButtons([button1Text]);
           }
         }
-        //Dashboards.showProgressIndicator();
+        if (this.panel) {
+          this.panel.dashboard.showProgressIndicator();
+        }
         messageBox.show();
       },
 
@@ -395,13 +399,13 @@ define(['common-ui/util/util', 'common-ui/util/formatting', 'pentaho/common/Mess
        * @param e Error/exception encountered
        */
       onFatalError: function(e) {
-        var errorMsg = pentaho.common.Messages.getString('ErrorParsingParamXmlMessage');
+        var errorMsg = Messages.getString('ErrorParsingParamXmlMessage');
         if (typeof console !== 'undefined' && console.log) {
           console.log(errorMsg + ": " + e);
         }
         this.showMessageBox(
           errorMsg,
-          pentaho.common.Messages.getString('FatalErrorTitle'));
+          Messages.getString('FatalErrorTitle'));
       }
     }); // return logged
   }; // return function

--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -28,8 +28,7 @@ define([ 'common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/ut
       prompt: reportPrompt,
 
       load: function() {
-        parser.parse();
-        pentaho.common.Messages.addUrlBundle('reportviewer', CONTEXT_PATH+'i18n?plugin=reporting&name=reportviewer/messages/messages');
+        _Messages.addUrlBundle('reportviewer', CONTEXT_PATH+'i18n?plugin=reporting&name=reportviewer/messages/messages');
         this.view.localize();
 
         this.createRequiredHooks();
@@ -117,8 +116,8 @@ define([ 'common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/ut
          * Localize the Report Viewer.
          */
         localize: function() {
-          $('#toolbar-parameterToggle').attr('title', pentaho.common.Messages.getString('parameterToolbarItem_title'));
-          registry.byId('pageControl').registerLocalizationLookup(pentaho.common.Messages.getString);
+          $('#toolbar-parameterToggle').attr('title', _Messages.getString('parameterToolbarItem_title'));
+          registry.byId('pageControl').registerLocalizationLookup(_Messages.getString);
         },
 
         /**
@@ -608,7 +607,7 @@ define([ 'common-ui/util/util','reportviewer/reportviewer-prompt', 'common-ui/ut
       openUrlInDialog: function(title, url, width, height) {
         if (this.dialog === undefined) {
           this.dialog = new pentaho.reportviewer.ReportDialog();
-          this.dialog.setLocalizationLookupFunction(pentaho.common.Messages.getString);
+          this.dialog.setLocalizationLookupFunction(_Messages.getString);
         }
         this.dialog.open(title, url, width, height);
       },


### PR DESCRIPTION
1. Replace using Dashboards to dashboard object from panel.
2. Remove parser.parse(); to avoid error in console: "dojo/parser::parse() error Error: Tried to register widget with id==glassPane but that id is already registered".
3. Replace using pentaho.common.Messages to already defined module.

@diogofscmariano @krivera-pentaho @scottyaslan @rfellows @plagoa please review.