### PR TITLE
[SP-2164][BISERVER-12767] Resolve issue where the ScrollableResultSet…

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/cache/PentahoDataCache.java
+++ b/src/org/pentaho/reporting/platform/plugin/cache/PentahoDataCache.java
@@ -37,7 +37,7 @@ import org.pentaho.reporting.engine.classic.core.cache.DataCacheManager;
 /**
  * A simple data cache that wraps around the plain in-memory data-cache. That cache is stored on the user's session and
  * shared across all reports run by that user in that session.
- * 
+ *
  * @author Thomas Morgner.
  */
 public class PentahoDataCache implements DataCache, ILogoutListener {
@@ -205,6 +205,7 @@ public class PentahoDataCache implements DataCache, ILogoutListener {
       }
       final TableModel cacheModel = new CachableTableModel( model );
       cacheManager.putInRegionCache( CACHE_NAME, new CompositeKey( session.getId(), key ), cacheModel );
+      return cacheModel;
     }
     return model;
   }

--- a/test-src/org/pentaho/reporting/platform/plugin/MockTableModel.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/MockTableModel.java
@@ -1,0 +1,47 @@
+package org.pentaho.reporting.platform.plugin;
+
+import com.google.common.base.Objects;
+import org.pentaho.reporting.engine.classic.core.util.CloseableTableModel;
+
+import javax.swing.table.AbstractTableModel;
+
+public class MockTableModel extends AbstractTableModel implements CloseableTableModel {
+
+  Object[][] data;
+  int rowCount = 0;
+  int columnCount = 0;
+  boolean closed;
+
+  public MockTableModel( final Object[][] data ) {
+    this.data = Objects.firstNonNull( data, new Object[0][0] );
+    rowCount = this.data.length;
+    for ( int i = 0; i < this.data.length; i++ ) {
+      columnCount = Math.max( columnCount, this.data[i].length );
+    }
+  }
+
+  public MockTableModel() {
+    this( null );
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+  }
+
+  @Override
+  public int getRowCount() {
+    return rowCount;
+  }
+
+  @Override
+  public int getColumnCount() {
+    return columnCount;
+  }
+
+  @Override
+  public Object getValueAt( final int rowIndex, final int columnIndex ) {
+    return data[rowIndex][columnIndex];
+  }
+
+}

--- a/test-src/org/pentaho/reporting/platform/plugin/cache/PentahoDataCacheTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/cache/PentahoDataCacheTest.java
@@ -1,0 +1,68 @@
+package org.pentaho.reporting.platform.plugin.cache;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.StandaloneSession;
+import org.pentaho.reporting.engine.classic.core.cache.DataCacheKey;
+import org.pentaho.reporting.platform.plugin.MockTableModel;
+
+import javax.swing.table.TableModel;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+
+public class PentahoDataCacheTest {
+
+  private PentahoDataCache dataCache;
+  private DataCacheKey dataCacheKey;
+  private MockTableModel tableModel;
+
+  @Before
+  public void setup() throws Exception {
+    createPentahoSession();
+    setupDataCache();
+    setupDataCacheKey();
+    setupTableModel();
+  }
+
+  @After
+  public void teardown() throws Exception {
+    destroyPentahoSession();
+  }
+
+  @Test
+  public void verifyReturnTableModelShouldBeDifferentThanTheOriginalTableModel() {
+    assertNull( "The data should not be cached.", dataCache.get( dataCacheKey ) );
+
+    TableModel cachedModel = dataCache.put( dataCacheKey, tableModel );
+
+    assertNotNull( "The data should be cached.", dataCache.get( dataCacheKey ) );
+    assertNotSame( "The original table model should not be returned.", tableModel, cachedModel );
+  }
+
+  private void createPentahoSession() {
+    PentahoSessionHolder.setSession( new StandaloneSession() );
+  }
+
+  private void destroyPentahoSession() {
+    PentahoSessionHolder.setSession( null );
+  }
+
+  private void setupDataCache() {
+    dataCache = new PentahoDataCache();
+  }
+
+  private void setupDataCacheKey() {
+    dataCacheKey = new DataCacheKey();
+    dataCacheKey.addParameter( "someParameter1", "someValue1" );
+    dataCacheKey.addParameter( "someParameter2", "someValue2" );
+  }
+
+  private void setupTableModel() {
+    tableModel = new MockTableModel();
+  }
+
+}


### PR DESCRIPTION
…TableModel is not closed after caching.  Leaving the underlying resultset open can lead to "maximum open cursors limit exceeded" errors in Oracle.