### PR TITLE
PDB-1869 - Dashboard displays a blank PIR report if it contains a Prompt with option 'Allow multiple selections'(Additional pull-request)

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/ReportContentUtil.java
+++ b/src/org/pentaho/reporting/platform/plugin/ReportContentUtil.java
@@ -122,9 +122,7 @@ public class ReportContentUtil {
     if ( def instanceof String ) {
       String s = (String) def;
       String[] result = s.split( "," );
-      if ( result.length > 1 ) {
-        def = result;
-      }
+      def = result;
     }
 
     if ( allowMultiSelect && Collection.class.isInstance( value ) ) {


### PR DESCRIPTION
Additional pull-request to https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/177
Fix updated for the case when user set 'Allow multiple selections' and choose only one option.
@pamval 
Please review.
