### PR TITLE
[BACKLOG-6961] Fixed usage of underscore dependency

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -15,7 +15,7 @@
 * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
 */
 
-define(['common-ui/util/util', 'pentaho/common/Messages', "dijit/registry", 'common-ui/prompting/parameters/ParameterXmlParser', "common-ui/prompting/api/PromptingAPI", "common-ui/jquery-clean", "common-ui/underscore"],
+define(['common-ui/util/util', 'pentaho/common/Messages', "dijit/registry", 'common-ui/prompting/parameters/ParameterXmlParser', "common-ui/prompting/api/PromptingAPI", "common-ui/jquery-clean", "underscore"],
 
     function(util, Messages, registry, ParameterXmlParser, PromptingAPI, $, _) {
       var _api =  new PromptingAPI('promptPanel');


### PR DESCRIPTION
Relates with PIR, fix the problem:

[exec] Tracing dependencies for: pir/module
      [exec] Error: Error: Module loading did not complete for: pir/module, reportviewer/reportviewer-main-module, reportviewer/reportviewer-prompt, common-ui/underscore
      [exec] The following modules share the same URL. This could be a misconfiguration if that URL only has one anonymous module in it:
      [exec] /build-shared/slave2/workspace/master-snapshot/pir-plugin/bin/scriptOutput/common-ui/underscore/underscore.js: common-ui/underscore, underscore
      [exec]     at Function.build.checkForErrors (/build-shared/slave2/workspace/master-snapshot/pir-plugin/build-res/pentaho-js-build/r.js:29996:19)
      [exec]

@pentaho/orlandocalisbon please review