### PR TITLE
[CLEAN-UP] - refactor IPentahoAsyncExecutor to be able to submit callable by interface

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/BackgroundJobReportContentGenerator.java
+++ b/src/org/pentaho/reporting/platform/plugin/BackgroundJobReportContentGenerator.java
@@ -85,9 +85,7 @@ public class BackgroundJobReportContentGenerator extends ParameterContentGenerat
     reportComponent.setOutputStream( handler.getStagingOutputStream() );
 
     PentahoAsyncReportExecution
-        asyncExec = new PentahoAsyncReportExecution( path, reportComponent, handler );
-    asyncExec.forSession( userSession.getId() );
-    asyncExec.forInstanceId( instanceId );
+        asyncExec = new PentahoAsyncReportExecution( path, reportComponent, handler, instanceId );
 
     PentahoAsyncExecutor executor =
       PentahoSystem.get( PentahoAsyncExecutor.class, PentahoAsyncExecutor.BEAN_NAME, null );

--- a/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportExecution.java
@@ -18,20 +18,6 @@ public interface IAsyncReportExecution<T> extends Callable<T> {
   String getMimeType();
 
   /**
-   * Set user session string id to be used for auditing.
-   *
-   * @param userSession - string session id for audit pusposes
-   */
-  void forSession( String userSession );
-
-  /**
-   * Set instance id for auditing purposes
-   *
-   * @param instanceId - string instance id
-   */
-  void forInstanceId( String instanceId );
-
-  /**
    * Attempt to cancel running task. Exact implementation can also provide
    * some additional clean-up.
    */

--- a/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportExecution.java
@@ -4,9 +4,37 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.RunnableFuture;
 
 public interface IAsyncReportExecution<T> extends Callable<T> {
-
   void setListener( IAsyncReportListener listener );
 
+  IAsyncReportState getState();
+  String getReportPath();
+
+  /**
+   * Get generated content mime-type suggestion to
+   * set proper http response header
+   *
+   * @return
+   */
+  String getMimeType();
+
+  /**
+   * Set user session string id to be used for auditing.
+   *
+   * @param userSession - string session id for audit pusposes
+   */
+  void forSession( String userSession );
+
+  /**
+   * Set instance id for auditing purposes
+   *
+   * @param instanceId - string instance id
+   */
+  void forInstanceId( String instanceId );
+
+  /**
+   * Attempt to cancel running task. Exact implementation can also provide
+   * some additional clean-up.
+   */
   void cancel();
 
   RunnableFuture<T> newTask();

--- a/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportListener.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportListener.java
@@ -2,7 +2,7 @@ package org.pentaho.reporting.platform.plugin.async;
 
 import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
 
-public interface IAsyncReportListener extends ReportProgressListener {
+public interface IAsyncReportListener extends ReportProgressListener, IAsyncReportState {
 
   void setStatus( AsyncExecutionStatus status );
 

--- a/src/org/pentaho/reporting/platform/plugin/async/IPentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IPentahoAsyncExecutor.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Future;
  * Created by dima.prokopenko@gmail.com on 2/25/2016.
  */
 public interface IPentahoAsyncExecutor {
-  UUID addTask( PentahoAsyncReportExecution task, IPentahoSession session );
+  UUID addTask( IAsyncReportExecution<InputStream> task, IPentahoSession session );
 
   Future<InputStream> getFuture( UUID id, IPentahoSession session );
 

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
@@ -77,7 +77,7 @@ public class PentahoAsyncExecutor implements ILogoutListener, IPentahoSystemList
     }
   }
 
-  @Override public UUID addTask( final PentahoAsyncReportExecution task, final IPentahoSession session ) {
+  @Override public UUID addTask( final IAsyncReportExecution<InputStream> task, final IPentahoSession session ) {
 
     final UUID id = UUID.randomUUID();
     final CompositeKey key = new CompositeKey( session, id );

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
@@ -41,6 +41,7 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
 
   @Override
   public InputStream call() throws Exception {
+    listener.setStatus( AsyncExecutionStatus.WORKING );
     PentahoSessionHolder.setSession( safeSession );
     try {
       ReportListenerThreadHolder.setListener( listener );
@@ -104,8 +105,8 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
     this.listener = listener;
   }
 
-  public IAsyncReportListener getListener() {
-    return this.listener;
+  @Override public IAsyncReportState getState() {
+    return listener;
   }
 
   public String getMimeType() {

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
@@ -9,6 +9,7 @@ import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
 
 import java.io.InputStream;
+import java.util.UUID;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 
@@ -18,42 +19,42 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
   private AsyncJobFileStagingHandler handler;
   private String url;
 
-  private String userSession = "";
-  private String instanceId = "";
+  private String instanceId = UUID.randomUUID().toString();
   private final IPentahoSession safeSession;
 
   private IAsyncReportListener listener;
 
-  public PentahoAsyncReportExecution( final String url, final SimpleReportingComponent reportComponent, final AsyncJobFileStagingHandler handler ) {
+  /**
+   * Creates callable execuiton task.
+   *
+   * @param url             for audit purposes
+   * @param reportComponent component responsible for gererating report
+   * @param handler         content staging handler between requests
+   * @param instanceId      id of caller. Used to track state of task. For example gap between submission and actual execution start
+   */
+  public PentahoAsyncReportExecution( final String url, final SimpleReportingComponent reportComponent,
+      final AsyncJobFileStagingHandler handler, String instanceId ) {
     this.reportComponent = reportComponent;
     this.handler = handler;
     this.url = url;
+    this.instanceId = instanceId == null ? UUID.randomUUID().toString() : instanceId;
     this.safeSession = PentahoSessionHolder.getSession();
   }
 
-  public void forSession( final String userSession ) {
-    this.userSession = userSession;
-  }
-
-  public void forInstanceId( final String instanceId ) {
-    this.instanceId = instanceId;
-  }
-
-  @Override
-  public InputStream call() throws Exception {
+  @Override public InputStream call() throws Exception {
     listener.setStatus( AsyncExecutionStatus.WORKING );
     PentahoSessionHolder.setSession( safeSession );
     try {
       ReportListenerThreadHolder.setListener( listener );
       final long start = System.currentTimeMillis();
-      AuditHelper.audit( userSession, userSession, url, getClass().getName(), getClass()
-        .getName(), MessageTypes.INSTANCE_START, instanceId, "", 0, null );
+      AuditHelper.audit( safeSession.getId(), safeSession.getId(), url, getClass().getName(), getClass().getName(),
+          MessageTypes.INSTANCE_START, instanceId, "", 0, null );
 
       if ( reportComponent.execute() ) {
 
         final long end = System.currentTimeMillis();
-        AuditHelper.audit( userSession, userSession, url, getClass().getName(), getClass()
-          .getName(), MessageTypes.INSTANCE_END, instanceId, "", ( (float) ( end - start ) / 1000 ), null );
+        AuditHelper.audit( safeSession.getId(), safeSession.getId(), url, getClass().getName(), getClass().getName(),
+            MessageTypes.INSTANCE_END, instanceId, "", ( (float) ( end - start ) / 1000 ), null );
 
         listener.setStatus( AsyncExecutionStatus.FINISHED );
 
@@ -62,8 +63,8 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
 
       listener.setStatus( AsyncExecutionStatus.FAILED );
 
-      AuditHelper.audit( userSession, userSession, url, getClass().getName(), getClass()
-        .getName(), MessageTypes.FAILED, instanceId, "", 0, null );
+      AuditHelper.audit( safeSession.getId(), safeSession.getId(), url, getClass().getName(), getClass().getName(),
+          MessageTypes.FAILED, instanceId, "", 0, null );
       return new NullInputStream( 0 );
     } finally {
       ReportListenerThreadHolder.clear();
@@ -80,7 +81,7 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
 
   @Override public RunnableFuture<InputStream> newTask() {
     return new FutureTask<InputStream>( this ) {
-      public boolean cancel( final boolean mayInterruptIfRunning )  {
+      public boolean cancel( final boolean mayInterruptIfRunning ) {
         try {
           if ( mayInterruptIfRunning ) {
             PentahoAsyncReportExecution.this.cancel();
@@ -93,15 +94,11 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
   }
 
   @Override public String toString() {
-    return "PentahoAsyncReportExecution{"
-      + "url='" + url + '\''
-      + ", instanceId='" + instanceId + '\''
-      + ", listener=" + listener
-      + '}';
+    return "PentahoAsyncReportExecution{" + "url='" + url + '\'' + ", instanceId='" + instanceId + '\'' + ", listener="
+        + listener + '}';
   }
 
-  @Override
-  public void setListener( final IAsyncReportListener listener ) {
+  @Override public void setListener( final IAsyncReportListener listener ) {
     this.listener = listener;
   }
 

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionInterrupt.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionInterrupt.java
@@ -65,7 +65,7 @@ public class PentahoAsyncExecutionInterrupt {
         handler =
         new AsyncJobFileStagingHandler( session );
     PentahoAsyncReportExecution
-        task = new PentahoAsyncReportExecution( "junit", reportComponent, handler );
+        task = new PentahoAsyncReportExecution( "junit", reportComponent, handler, null );
 
     UUID id = executor.addTask( task, session );
 

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
@@ -66,7 +66,7 @@ public class PentahoAsyncExecutionTest {
     when( component.execute() ).thenReturn( true );
 
     PentahoAsyncReportExecution
-      exec = new PentahoAsyncReportExecution( "junit-path", component, handler );
+      exec = new PentahoAsyncReportExecution( "junit-path", component, handler, null );
     AsyncReportStatusListener listner = new AsyncReportStatusListener( "display_path", UUID.randomUUID(), "text/html" );
 
     exec.setListener( listner );
@@ -87,7 +87,7 @@ public class PentahoAsyncExecutionTest {
     when( component.execute() ).thenReturn( false );
 
     PentahoAsyncReportExecution
-      exec = new PentahoAsyncReportExecution( "junit-path", component, handler );
+      exec = new PentahoAsyncReportExecution( "junit-path", component, handler, null );
     AsyncReportStatusListener listener =
       new AsyncReportStatusListener( "display_path", UUID.randomUUID(), "text/html" );
 
@@ -122,7 +122,7 @@ public class PentahoAsyncExecutionTest {
   }
 
   private PentahoAsyncReportExecution getSleepingSpy( final AtomicBoolean run ) {
-    PentahoAsyncReportExecution exec = new PentahoAsyncReportExecution( "junit-path", component, handler ) {
+    PentahoAsyncReportExecution exec = new PentahoAsyncReportExecution( "junit-path", component, handler, null ) {
       @Override
       public InputStream call() throws Exception {
         while ( !run.get() && !Thread.currentThread().isInterrupted() ) {

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
@@ -137,6 +137,6 @@ public class PentahoAsyncExecutionTest {
   }
 
   private AsyncReportStatusListener extractImpl( final PentahoAsyncReportExecution e ) {
-    return (AsyncReportStatusListener) e.getListener();
+    return (AsyncReportStatusListener) e.getState();
   }
 }

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
@@ -76,7 +76,7 @@ public class PentahoAsyncReportExecutorTest {
   final InputStream input = new NullInputStream( 0 );
 
   PentahoAsyncReportExecution
-      task1 = new PentahoAsyncReportExecution( "junit-path", component, handler );
+      task1 = new PentahoAsyncReportExecution( "junit-path", component, handler, null );
 
   @Before public void before() throws Exception {
     when( handler.getStagingContent() ).thenReturn( input );


### PR DESCRIPTION
- refactor IPentahoAsyncExecutor to be able to submit callable by interface
- remove redundant forSession forInstanceId methods form interface.
- move instance id to a constructor as optional (possible null) parametr