### PR TITLE
[BACKLOG-7169],  	[BACKLOG-7181], junit test clean up.

### DIFF
--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
@@ -19,11 +19,14 @@
 package org.pentaho.reporting.platform.plugin.async;
 
 import org.apache.commons.io.input.NullInputStream;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.libraries.base.config.ModifiableConfiguration;
 import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
@@ -56,9 +59,20 @@ public class PentahoAsyncExecutionTest {
 
   @Before
   public void before() throws Exception {
+    PentahoSystem.clearObjectFactory();
+    PentahoSessionHolder.removeSession();
+
+    PentahoSessionHolder.setSession( userSession );
+
     when( handler.getStagingContent() ).thenReturn( input );
     when( report.getReportConfiguration() ).thenReturn( configuration );
     when( component.getReport() ).thenReturn( report );
+  }
+
+  @After
+  public void after() {
+    PentahoSystem.clearObjectFactory();
+    PentahoSessionHolder.removeSession();
   }
 
   @Test

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
@@ -20,12 +20,14 @@ package org.pentaho.reporting.platform.plugin.async;
 
 import junit.framework.Assert;
 import org.apache.commons.io.input.NullInputStream;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 import org.pentaho.platform.api.engine.IApplicationContext;
 import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.libraries.base.config.ModifiableConfiguration;
@@ -77,6 +79,10 @@ public class PentahoAsyncReportExecutorTest {
   final InputStream input = new NullInputStream( 0 );
 
   @Before public void before() throws Exception {
+    PentahoSystem.clearObjectFactory();
+    PentahoSessionHolder.removeSession();
+
+
     when( handler.getStagingContent() ).thenReturn( input );
     when( report.getReportConfiguration() ).thenReturn( configuration );
     when( component.getReport() ).thenReturn( report );
@@ -94,8 +100,16 @@ public class PentahoAsyncReportExecutorTest {
     PentahoSystem.setApplicationContext( context );
   }
 
+  @After
+  public void after() {
+    PentahoSystem.clearObjectFactory();
+    PentahoSessionHolder.removeSession();
+  }
+
   @Test public void testCanCompleteTask() throws Exception {
     when( component.execute() ).thenReturn( true );
+    PentahoSessionHolder.setSession( session1 );
+
 
     PentahoAsyncReportExecution task1 = createMockCallable();
 

--- a/test-src/org/pentaho/reporting/platform/plugin/async/TestInterruptionInterceptionTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/TestInterruptionInterceptionTest.java
@@ -19,9 +19,16 @@
 package org.pentaho.reporting.platform.plugin.async;
 
 import org.apache.commons.io.output.NullOutputStream;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.modules.output.pageable.pdf.PdfReportUtil;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * See BACKLOG-7081 for additional details.
@@ -29,6 +36,21 @@ import org.pentaho.reporting.engine.classic.core.modules.output.pageable.pdf.Pdf
  * Created by dima.prokopenko@gmail.com on 3/15/2016.
  */
 public class TestInterruptionInterceptionTest {
+
+  IPentahoSession userSession = mock( IPentahoSession.class );
+
+  @Before
+  public void before() {
+    PentahoSystem.clearObjectFactory();
+    PentahoSessionHolder.removeSession();
+    PentahoSessionHolder.setSession( userSession );
+  }
+
+  @After
+  public void after() {
+    PentahoSystem.clearObjectFactory();
+    PentahoSessionHolder.removeSession();
+  }
 
   @Test public void testInterruptFlagProblem() throws Exception {
     PentahoAsyncExecutionInterruptTest t1 = new PentahoAsyncExecutionInterruptTest();


### PR DESCRIPTION
This brings:

- tests cleanup - since we don't fork junits we have side effects on code from one test attempts to set somthing to a static context, while in other tests this static context unexpectedly becomes available.
- [BACKLOG-7181] - use mega-greed catch block to catch exception as far as errors. Errors like NoSuchMethod error while jars incompatible with dependencies. We should avoid hang on working status.
- [BACKLOG-7169] - fix job manager to use proper content headers.
