### PR TITLE
[BACKLOG-7204] Remove total page update on each status and update 

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -849,9 +849,6 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
                     var urlStatus = url.substring(0, url.indexOf("/api/repos")) + '/plugin/reporting/api/jobs/' + resultJson.uuid + '/status';
                     setTimeout(function(){ pentahoGet(urlStatus, "", handleResultCallback); }, 1000);
                   } else {
-                    //update page number
-                    var pageContr = registry.byId('pageControl');
-                    pageContr.setPageCount(resultJson.page);
 
                     var urlStatus = url.substring(0, url.indexOf("/api/repos")) + '/plugin/reporting/api/jobs/' + resultJson.uuid + '/status';
                     setTimeout(function(){ pentahoGet(urlStatus, "", handleResultCallback); }, 1000);


### PR DESCRIPTION
We don't need it because we will have a popup with status updates soon.
Also it is useless anyway - we update cache only when report is finished.

Thomas, please review.

@tmorgner 