### PR TITLE
Backlog 7352 - Fix '-1' row quantity in the end of generation

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListener.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListener.java
@@ -81,7 +81,6 @@ class AsyncReportStatusListener implements IAsyncReportListener {
 
   @Override
   public synchronized void reportProcessingFinished( final ReportProgressEvent event ) {
-    updateState( event );
     this.status = AsyncExecutionStatus.FINISHED;
   }
 

--- a/src/org/pentaho/reporting/platform/plugin/output/CachingPageableHTMLOutput.java
+++ b/src/org/pentaho/reporting/platform/plugin/output/CachingPageableHTMLOutput.java
@@ -171,9 +171,11 @@ public class CachingPageableHTMLOutput extends PageableHTMLOutput {
         logger.warn( "Using cached report data for " + key );
         final ReportProgressListener listener = ReportListenerThreadHolder.getListener();
         if ( listener != null ) {
-          listener.reportProcessingFinished(
-            new ReportProgressEvent( "Cache", ReportProgressEvent.GENERATING_CONTENT, 0, 0,
-              acceptedPage + 1, cachedContent.getPageCount(), 0,  0 ) );
+          final ReportProgressEvent event =
+            new ReportProgressEvent( this, ReportProgressEvent.GENERATING_CONTENT, 0, 0,
+              acceptedPage + 1, cachedContent.getPageCount(), 0, 0 );
+          listener.reportProcessingUpdate( event );
+          listener.reportProcessingFinished( event );
         }
         outputStream.write( page );
         outputStream.flush();

--- a/test-src/org/pentaho/reporting/platform/plugin/PageableHTMLTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/PageableHTMLTest.java
@@ -558,6 +558,8 @@ public class PageableHTMLTest {
       assertTrue( listener.isOnUpdate() );
       assertTrue( listener.isOnFinish() );
       assertTrue( listener.isOnFirstPage() );
+      assertFalse( -1 == listener.getState().getRow());
+      assertFalse( -1 == listener.getState().getTotalRows());
 
       ReportListenerThreadHolder.clear();
 
@@ -572,7 +574,7 @@ public class PageableHTMLTest {
       execute( r2 );
 
       assertFalse( listener2.isOnStart() );
-      assertFalse( listener2.isOnUpdate() );
+      assertTrue( listener2.isOnUpdate() );
       assertTrue( listener2.isOnFinish() );
       assertFalse( listener2.isOnFirstPage() );
 
@@ -603,6 +605,8 @@ public class PageableHTMLTest {
       assertTrue( listener.isOnUpdate() );
       assertTrue( listener.isOnFinish() );
       assertFalse( listener.isOnFirstPage() );
+      assertFalse( -1 == listener.getState().getRow());
+      assertFalse( -1 == listener.getState().getTotalRows());
 
       ReportListenerThreadHolder.clear();
 
@@ -617,7 +621,7 @@ public class PageableHTMLTest {
       execute( r2 );
 
       assertFalse( listener2.isOnStart() );
-      assertFalse( listener2.isOnUpdate() );
+      assertTrue( listener2.isOnUpdate() );
       assertTrue( listener2.isOnFinish() );
       assertFalse( listener2.isOnFirstPage() );
 


### PR DESCRIPTION
AbstractReportProcessor creates new event when calling listener.reportProcessingFinished/
This new event has default values for the fields, so we can ignore them and just update the status.

Thomas, take a look please.

@tmorgner 
