### PR TITLE
Backlog 7204

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -950,7 +950,7 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
 
           //Navigation on report in progress section
           var reportUrl = url.substring(url.lastIndexOf("/report?")+"/report?".length, url.length);
-          if(this._currentReportStatus && this._currentReportStatus!='FINISHED'){
+          if(this._currentReportStatus && this._currentReportStatus!='FINISHED' && this._currentReportStatus!='FAILED' && this._currentReportStatus!='CANCELED'){
              //In progress
             var acceptedPage = me.view._getAcceptedPage();
             if(this._currentStoredPagesCount > acceptedPage){

--- a/src/org/pentaho/reporting/platform/plugin/async/AsyncReportState.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AsyncReportState.java
@@ -3,99 +3,107 @@ package org.pentaho.reporting.platform.plugin.async;
 import java.util.UUID;
 
 public class AsyncReportState implements IAsyncReportState {
-    private final String path;
-    private final UUID uuid;
-    private final AsyncExecutionStatus status;
-    private final int progress;
-    private final int page;
-    private final int totalPages;
-    private final int row;
-    private final int totalRows;
-    private final String activity;
-    private final String mimeType;
+  private final String path;
+  private final UUID uuid;
+  private final AsyncExecutionStatus status;
+  private final int progress;
+  private final int page;
+  private final int totalPages;
+  private final int row;
+  private final int totalRows;
+  private final String activity;
+  private final String mimeType;
+  private final int generatedPage;
 
-    public AsyncReportState(final UUID id, final String path) {
-        this.status = AsyncExecutionStatus.QUEUED;
-        this.uuid = id;
-        this.path = path;
-        this.progress = 0;
-        this.page = 0;
-        this.totalPages = 0;
-        this.row = 0;
-        this.totalRows = 0;
-        this.activity = null;
-        this.mimeType = null;
-    }
+  public AsyncReportState( final UUID id, final String path ) {
+    this.status = AsyncExecutionStatus.QUEUED;
+    this.uuid = id;
+    this.path = path;
+    this.progress = 0;
+    this.page = 0;
+    this.totalPages = 0;
+    this.generatedPage = 0;
+    this.row = 0;
+    this.totalRows = 0;
+    this.activity = null;
+    this.mimeType = null;
+  }
 
-    public AsyncReportState(final UUID uuid,
-                            final String path,
-                            final AsyncExecutionStatus status,
-                            final int progress,
-                            final int row,
-                            final int totalRows,
-                            final int page,
-                            final int totalPages,
-                            final String activity,
-                            final String mimeType) {
-        this.uuid = uuid;
-        this.path = path;
-        this.status = status;
-        this.progress = progress;
-        this.row = row;
-        this.totalRows = totalRows;
-        this.page = page;
-        this.totalPages = totalPages;
-        this.activity = activity;
-        this.mimeType = mimeType;
-    }
+  public AsyncReportState( final UUID uuid,
+                           final String path,
+                           final AsyncExecutionStatus status,
+                           final int progress,
+                           final int row,
+                           final int totalRows,
+                           final int page,
+                           final int totalPages,
+                           final int generatedPage,
+                           final String activity,
+                           final String mimeType ) {
+    this.uuid = uuid;
+    this.path = path;
+    this.status = status;
+    this.progress = progress;
+    this.row = row;
+    this.totalRows = totalRows;
+    this.page = page;
+    this.totalPages = totalPages;
+    this.generatedPage = generatedPage;
+    this.activity = activity;
+    this.mimeType = mimeType;
+  }
 
-    @Override
-    public String getPath() {
-        return path;
-    }
+  @Override
+  public String getPath() {
+    return path;
+  }
 
-    @Override
-    public UUID getUuid() {
-        return uuid;
-    }
+  @Override
+  public UUID getUuid() {
+    return uuid;
+  }
 
-    @Override
-    public AsyncExecutionStatus getStatus() {
-        return status;
-    }
+  @Override
+  public AsyncExecutionStatus getStatus() {
+    return status;
+  }
 
-    @Override
-    public int getProgress() {
-        return progress;
-    }
+  @Override
+  public int getProgress() {
+    return progress;
+  }
 
-    @Override
-    public int getPage() {
-        return page;
-    }
+  @Override
+  public int getPage() {
+    return page;
+  }
 
-    @Override
-    public int getTotalPages() {
-        return totalPages;
-    }
+  @Override
+  public int getTotalPages() {
+    return totalPages;
+  }
 
-    @Override
-    public int getRow() {
-        return row;
-    }
+  @Override public int getGeneratedPage() {
+    return generatedPage;
+  }
 
-    @Override
-    public int getTotalRows() {
-        return totalRows;
-    }
+  @Override
+  public int getRow() {
+    return row;
+  }
 
-    @Override
-    public String getActivity() {
-        return activity;
-    }
+  @Override
+  public int getTotalRows() {
+    return totalRows;
+  }
 
-    @Override
-    public String getMimeType() {
-        return mimeType;
-    }
+  @Override
+  public String getActivity() {
+    return activity;
+  }
+
+  @Override
+  public String getMimeType() {
+    return mimeType;
+  }
 }

--- a/src/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListener.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListener.java
@@ -46,6 +46,8 @@ class AsyncReportStatusListener implements IAsyncReportListener {
   private int totalRows = 0;
   private String activity;
   private boolean firstPageMode = false;
+  private int requestedPage = 0;
+  private int generatedPage = 0;
 
 
   AsyncReportStatusListener( final String path,
@@ -69,6 +71,26 @@ class AsyncReportStatusListener implements IAsyncReportListener {
     return firstPageMode;
   }
 
+
+  public synchronized void setRequestedPage( final int requestedPage ) {
+    this.requestedPage = requestedPage;
+  }
+
+  @Override public synchronized int getRequestedPage() {
+    return requestedPage;
+  }
+
+  /**
+   * Updates generation status with latest generated page
+   * and restores requested page in order to avoid continuous cache writing
+   * @param generatedPage
+   */
+  @Override public synchronized void updateGenerationStatus( final int generatedPage ) {
+    this.generatedPage = generatedPage;
+    this.requestedPage = 0;
+  }
+
+
   @Override
   public synchronized void reportProcessingStarted( final ReportProgressEvent event ) {
     this.status = AsyncExecutionStatus.WORKING;
@@ -91,6 +113,8 @@ class AsyncReportStatusListener implements IAsyncReportListener {
       + ", status=" + status
       + ", progress=" + progress
       + ", page=" + page
+      + ", totalPages=" + totalPages
+      + ", generatedPage=" + generatedPage
       + ", activity='" + activity + '\''
       + ", row=" + row
       + ", firstPageMode=" + firstPageMode
@@ -133,6 +157,6 @@ class AsyncReportStatusListener implements IAsyncReportListener {
   }
 
   public synchronized IAsyncReportState getState() {
-    return new AsyncReportState( uuid, path, status, progress, row, totalRows, page, totalPages, activity, mimeType );
+    return new AsyncReportState( uuid, path, status, progress, row, totalRows, page, totalPages, generatedPage, activity, mimeType );
   }
 }

--- a/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportExecution.java
@@ -11,7 +11,7 @@ public interface IAsyncReportExecution<T> extends Callable<T> {
    *
    * @param id
    */
-  void notifyTaskQueued(UUID id);
+  void notifyTaskQueued( UUID id );
 
   /**
    * Return the current state. Never null.
@@ -29,4 +29,6 @@ public interface IAsyncReportExecution<T> extends Callable<T> {
   String getMimeType();
 
   RunnableFuture<T> newTask();
+
+  void requestPage( int page );
 }

--- a/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportListener.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportListener.java
@@ -7,4 +7,9 @@ public interface IAsyncReportListener extends ReportProgressListener {
   void setStatus( AsyncExecutionStatus status );
 
   boolean isFirstPageMode();
+
+  int getRequestedPage();
+
+  void updateGenerationStatus( int generatedPage );
+
 }

--- a/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportState.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IAsyncReportState.java
@@ -3,9 +3,6 @@ package org.pentaho.reporting.platform.plugin.async;
 import java.io.Serializable;
 import java.util.UUID;
 
-/**
- * Created by dima.prokopenko@gmail.com on 2/12/2016.
- */
 public interface IAsyncReportState extends Serializable {
 
   /**
@@ -29,31 +26,31 @@ public interface IAsyncReportState extends Serializable {
   int getProgress();
 
   /**
-   *
    * @return Page is currently being processed
    */
   int getPage();
 
   /**
-   *
    * @return Quantity of pages in the report
    */
   int getTotalPages();
 
   /**
-   *
+   * @return Quantity of pages that were already generated
+   */
+  int getGeneratedPage();
+
+  /**
    * @return Row is currently being processed
    */
   int getRow();
 
   /**
-   *
    * @return Quantity of rows in the report
    */
   int getTotalRows();
 
   /**
-   *
    * @return Activity code is currently being processed
    */
   String getActivity();

--- a/src/org/pentaho/reporting/platform/plugin/async/IPentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/IPentahoAsyncExecutor.java
@@ -17,4 +17,6 @@ public interface IPentahoAsyncExecutor {
   IAsyncReportState getReportState( UUID id, IPentahoSession session );
 
   void cleanFuture( UUID id, IPentahoSession session );
+
+  void requestPage( UUID id, IPentahoSession session, int page );
 }

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
@@ -8,6 +8,7 @@ import org.pentaho.platform.api.engine.ILogoutListener;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IPentahoSystemListener;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.reporting.libraries.base.util.ArgumentNullException;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
 
 import java.io.File;
@@ -119,12 +120,8 @@ public class PentahoAsyncExecutor implements ILogoutListener, IPentahoSystemList
   }
 
   private void validateParams( final UUID id, final IPentahoSession session ) {
-    if ( id == null ) {
-      throw new NullPointerException( "uuid is null" );
-    }
-    if ( session == null ) {
-      throw new NullPointerException( "Session is null" );
-    }
+    ArgumentNullException.validate( "uuid", id );
+    ArgumentNullException.validate( "session", session );
   }
 
   @Override public void onLogout( final IPentahoSession iPentahoSession ) {

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
@@ -93,12 +93,7 @@ public class PentahoAsyncExecutor implements ILogoutListener, IPentahoSystemList
   }
 
   @Override public Future<InputStream> getFuture( final UUID id, final IPentahoSession session ) {
-    if ( id == null ) {
-      throw new NullPointerException( "uuid is null" );
-    }
-    if ( session == null ) {
-      throw new NullPointerException( "Session is null" );
-    }
+    validateParams( id, session );
     return futures.get( new CompositeKey( session, id ) );
   }
 
@@ -108,16 +103,28 @@ public class PentahoAsyncExecutor implements ILogoutListener, IPentahoSystemList
     tasks.remove( key );
   }
 
+  @Override public void requestPage( final UUID id, final IPentahoSession session, final int page ) {
+    validateParams( id, session );
+    final IAsyncReportExecution<InputStream> runningTask = tasks.get( new CompositeKey( session, id ) );
+    if ( runningTask != null ) {
+      runningTask.requestPage( page );
+    }
+  }
+
   @Override public IAsyncReportState getReportState( final UUID id, final IPentahoSession session ) {
+    validateParams( id, session );
+    // link to running task
+    final IAsyncReportExecution<InputStream> runningTask = tasks.get( new CompositeKey( session, id ) );
+    return runningTask == null ? null : runningTask.getState();
+  }
+
+  private void validateParams( final UUID id, final IPentahoSession session ) {
     if ( id == null ) {
       throw new NullPointerException( "uuid is null" );
     }
     if ( session == null ) {
-      throw new NullPointerException( "session is null" );
+      throw new NullPointerException( "Session is null" );
     }
-    // link to running task
-    final IAsyncReportExecution<InputStream> runningTask = tasks.get( new CompositeKey( session, id ) );
-    return runningTask == null ? null : runningTask.getState();
   }
 
   @Override public void onLogout( final IPentahoSession iPentahoSession ) {

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
@@ -38,7 +38,7 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
   public PentahoAsyncReportExecution( final String url,
                                       final SimpleReportingComponent reportComponent,
                                       final AsyncJobFileStagingHandler handler,
-                                      final String auditId) {
+                                      final String auditId ) {
     this.reportComponent = reportComponent;
     this.handler = handler;
     this.url = url;
@@ -46,13 +46,13 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
     this.safeSession = PentahoSessionHolder.getSession();
   }
 
-  public void notifyTaskQueued(UUID id) {
-    ArgumentNullException.validate("id", id);
+  public void notifyTaskQueued( final UUID id ) {
+    ArgumentNullException.validate( "id", id );
 
-    if (listener != null) {
-      throw new IllegalStateException("This instance has already been scheduled.");
+    if ( listener != null ) {
+      throw new IllegalStateException( "This instance has already been scheduled." );
     }
-    this.listener = createListener(id);
+    this.listener = createListener( id );
   }
 
   /**
@@ -90,7 +90,7 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
       // in case execute just returns false without an exception.
       fail();
       return new NullInputStream( 0 );
-    } catch ( Throwable ee ) {
+    } catch ( final Throwable ee ) {
       // it is bad practice to catch throwable.
       // but we has to to set proper execution status in any case.
       // Example: NoSuchMethodError (instance of Error) in case of usage of
@@ -112,7 +112,7 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
         MessageTypes.FAILED, auditId, "", 0, null );
   }
 
-  protected AsyncReportStatusListener createListener(UUID instanceId) {
+  protected AsyncReportStatusListener createListener( final UUID instanceId ) {
     return new AsyncReportStatusListener( getReportPath(), instanceId, getMimeType() );
   }
 
@@ -128,12 +128,16 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
           if ( mayInterruptIfRunning ) {
             PentahoAsyncReportExecution.this.cancel();
           }
-        } catch (final Exception e) {
+        } catch ( final Exception e ) {
           // ignored.
         }
         return super.cancel( mayInterruptIfRunning );
       }
     };
+  }
+
+  @Override public void requestPage( final int page ) {
+    listener.setRequestedPage( page );
   }
 
   @Override public String toString() {
@@ -142,8 +146,8 @@ public class PentahoAsyncReportExecution implements IAsyncReportExecution<InputS
   }
 
   @Override public IAsyncReportState getState() {
-    if (listener == null) {
-      throw new IllegalStateException("Cannot query state until job is added to the executor.");
+    if ( listener == null ) {
+      throw new IllegalStateException( "Cannot query state until job is added to the executor." );
     }
     return listener.getState();
   }

--- a/src/org/pentaho/reporting/platform/plugin/cache/IReportContent.java
+++ b/src/org/pentaho/reporting/platform/plugin/cache/IReportContent.java
@@ -26,6 +26,8 @@ public interface IReportContent extends Serializable {
 
   int getPageCount();
 
+  int getStoredPageCount();
+
   byte[] getPageData( final int page );
 
 }

--- a/src/org/pentaho/reporting/platform/plugin/cache/ReportContentImpl.java
+++ b/src/org/pentaho/reporting/platform/plugin/cache/ReportContentImpl.java
@@ -38,6 +38,13 @@ public class ReportContentImpl implements IReportContent {
     return pageCount;
   }
 
+  @Override public int getStoredPageCount() {
+    if ( reportData != null ) {
+      return reportData.size();
+    }
+    return 0;
+  }
+
   @Override public byte[] getPageData( final int page ) {
     return reportData.get( page );
   }

--- a/test-src/org/pentaho/reporting/platform/plugin/JobManagerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/JobManagerTest.java
@@ -24,8 +24,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.pentaho.platform.api.engine.IPentahoObjectFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
-import org.pentaho.platform.engine.core.system.IPentahoSessionHolderStrategy;
-import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.platform.plugin.async.AsyncExecutionStatus;
 import org.pentaho.reporting.platform.plugin.async.IAsyncReportState;
@@ -40,9 +38,6 @@ import static org.mockito.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-/**
- * Created by dima.prokopenko@gmail.com on 2/22/2016.
- */
 public class JobManagerTest extends JaxRsServerProvider {
 
   public static final String URL_FORMAT = "/reporting/api/jobs/%1$s%2$s";
@@ -70,6 +65,19 @@ public class JobManagerTest extends JaxRsServerProvider {
     // currently no simple way to restore to AsyncReportState interface here
     // at least we get uuid in return.
     assertTrue( json.contains( uuid.toString() ) );
+  }
+
+
+  @Test public void testRequestPage() throws IOException {
+    client.path( String.format( URL_FORMAT, UUID.randomUUID().toString(), "/requestPage/100" ) );
+
+    final Response response = client.get();
+    assertNotNull( response );
+    assertTrue( response.hasEntity() );
+
+    final String page = response.readEntity( String.class );
+
+    assertEquals( "100", page );
   }
 
   @BeforeClass public static void initialize() throws Exception {
@@ -121,6 +129,10 @@ public class JobManagerTest extends JaxRsServerProvider {
       }
 
       @Override public int getTotalPages() {
+        return 0;
+      }
+
+      @Override public int getGeneratedPage() {
         return 0;
       }
 


### PR DESCRIPTION
This one is about navigation through still running report.

How it works on UI:

1. ...
2.  User requests a new page.
3.  If generation have already been finished or page is in cache - just fire a job to get the page from cache. :ok_hand: 

   If not - send a request to the generation task to store the cache.
   When you see that page is now in cache - just fire a job to get it.


How it works on server side:

1. ...
2.  Somebody requested a page.
3.  If page is already available in processor - write to cache as much pages as you have and update generatedPages value.

   If not listen to events and do the job when it is.

I've recorderd a short [demo](https://dl.dropboxusercontent.com/u/71148577/page_navigation.webm)

Thomas, please take a look.
@tmorgner 
