### PR TITLE
[BACKLOG-7527] - Prevent updating content twice 

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -49,6 +49,7 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
       _requestedPage: 0,
       _previousPage: 0,
       _isReportHtmlPagebleOutputFormat : null,
+      _reportUrl : null,
 
       _bindPromptEvents: function() {
         var baseShowGlassPane = this.reportPrompt.showGlassPane.bind(this.reportPrompt);
@@ -994,7 +995,20 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
              //In progress
             if(this._currentStoredPagesCount > this._requestedPage){
               //Page available
-              isFinished = true;
+              var current = reportUrl.match(/(^.*accepted-page=)(\d*?)(&.*$)/);
+              var running = this._reportUrl.match(/(^.*accepted-page=)(\d*?)(&.*$)/);
+              //parameters besides accepted-page have been changed
+              if( current[1] != running[1] ){
+                this._reportUrl = reportUrl;
+                domClass.add('notification-screen', 'hidden');
+                this.cancel(this._currentReportStatus, this._currentReportUuid);
+                pentahoGet('reportjob', reportUrl, handleResultCallback, 'text/text');
+              } else {
+                //just different page, as far as requested page is updated 
+                //nothing to do here
+                isFinished = true;
+              }
+
             } else {
               //Need to wait for page
               var urlRequestPage = url.substring(0, url.indexOf("/api/repos")) + '/plugin/reporting/api/jobs/' + this._currentReportUuid
@@ -1017,6 +1031,7 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
             }
           } else {
             //Not started or finished
+            this._reportUrl = reportUrl;
             pentahoGet('reportjob', reportUrl, handleResultCallback, 'text/text');
           }
         } else {

--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -957,10 +957,14 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
 
                   if( (this._requestedPage > 0) && (this._currentStoredPagesCount > this._requestedPage)) {
                     // main request finished before requested page was stored in cache
-                    var newUrl =url.substring(url.lastIndexOf("/report?")+"/report?".length, url.length);
-                    newUrl = newUrl.replace(/(accepted-page=)\d*?(&)/,'$1' + this._requestedPage + '$2');
-                    this._requestedPage = 0;
-                    pentahoGet('reportjob', newUrl , handleContAvailCallback, 'text/text');
+                    var newUrl = url.substring(url.lastIndexOf("/report?") + "/report?".length, url.length);
+                    var match = newUrl.match(/(^.*accepted-page=)(\d*?)(&.*$)/);
+                    //if not handled by another job
+                    if(match[2] != this._requestedPage){
+                      newUrl = match[1] + this._requestedPage + match[3];
+                      this._requestedPage = 0;
+                      pentahoGet('reportjob', newUrl, handleContAvailCallback, 'text/text');
+                    }
                   }
 
                   isFinished = true;
@@ -990,7 +994,7 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
              //In progress
             if(this._currentStoredPagesCount > this._requestedPage){
               //Page available
-              pentahoGet('reportjob', reportUrl, handleResultCallback, 'text/text');
+              isFinished = true;
             } else {
               //Need to wait for page
               var urlRequestPage = url.substring(0, url.indexOf("/api/repos")) + '/plugin/reporting/api/jobs/' + this._currentReportUuid


### PR DESCRIPTION
Hello Thomas,

I've played with navigation for a while and noticed some redundant calls.
Here are the fixes:

1) If page is available and process is running we don't need to manually spawn another job it will be spawned by the main job ([line](https://github.com/EgorZhuk/pentaho-platform-plugin-reporting/blob/511f10ada2a9f9d24fe7da206538c1d959263c00/package-res/reportviewer/reportviewer.js#L922)).

2) Add another check to special case block ([line](https://github.com/EgorZhuk/pentaho-platform-plugin-reporting/blob/511f10ada2a9f9d24fe7da206538c1d959263c00/package-res/reportviewer/reportviewer.js#L958)) to avoid updating content twice.

@tmorgner 
