### PR TITLE
[BACKLOG-7782] - Avoid report generation in scheduling dialog

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -763,6 +763,12 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
       },
 
       _updateReportContentCore: function() {
+
+        //no report generation in scheduling dialog ever!
+        if(inSchedulerDialog){
+          return;
+        }
+
         var me = this;
 
         // PRD-3962 - remove glass pane after 5 seconds in case iframe onload/onreadystatechange was not detected


### PR DESCRIPTION
We simply don't need to generate report from scheduling dialog independently of chosen generation mode.

@tmorgner please review