### PR TITLE
[BACKLOG-7598] - Fix chrome pdf viewver plugin bogus behaviour

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/JobManager.java
+++ b/src/org/pentaho/reporting/platform/plugin/JobManager.java
@@ -80,6 +80,13 @@ public class JobManager {
     return null;
   }
 
+  @GET @Path( "{job_id}/content" )
+  public Response getPDFContent( @PathParam( "job_id" ) String job_id ) throws IOException {
+    logger.debug( "Chrome pdf viewer workaround. See BACKLOG-7598 fir details" );
+
+    return this.getContent( job_id );
+  }
+
   @POST @Path( "{job_id}/content" ) public Response getContent( @PathParam( "job_id" ) String job_id )
     throws IOException {
     UUID uuid = null;
@@ -117,9 +124,6 @@ public class JobManager {
       logger.error( "Error generating report", e );
       return Response.serverError().build();
     }
-    // ok we have InputStream so future will not be used anymore.
-    // release internal links to objects
-    executor.cleanFuture( uuid, session );
 
     StreamingOutput stream = new StreamingOutputWrapper( input.getStream() );
 

--- a/src/org/pentaho/reporting/platform/plugin/async/AbstractAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AbstractAsyncReportExecution.java
@@ -115,6 +115,10 @@ public abstract class AbstractAsyncReportExecution<TReportState extends IAsyncRe
     @Override public long getContentSize() {
       return 0;
     }
+
+    @Override public boolean cleanContent() {
+      return true;
+    }
   }
 
 

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
@@ -215,7 +215,7 @@ public class PentahoAsyncExecutor<TReportState extends IAsyncReportState>
         Futures.addCallback( value, new FutureCallback<IFixedSizeStreamingContent>() {
           @Override public void onSuccess( final IFixedSizeStreamingContent result ) {
             if ( result != null ) {
-              IOUtils.closeQuietly( result.getStream() );
+              result.cleanContent();
             }
           }
 

--- a/src/org/pentaho/reporting/platform/plugin/staging/IFixedSizeStreamingContent.java
+++ b/src/org/pentaho/reporting/platform/plugin/staging/IFixedSizeStreamingContent.java
@@ -7,7 +7,14 @@ import java.io.InputStream;
  */
 public interface IFixedSizeStreamingContent {
 
+  /**
+   * Creates input stream from staging content.
+   * This stream must be closed manually.
+   *
+   * @return
+   */
   InputStream getStream();
   long getContentSize();
+  boolean cleanContent();
 
 }

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
@@ -33,6 +33,7 @@ import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
 import org.pentaho.reporting.platform.plugin.staging.IFixedSizeStreamingContent;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.UUID;
 import java.util.concurrent.Future;
@@ -55,8 +56,7 @@ public class PentahoAsyncExecutionTest {
   IPentahoSession userSession = mock( IPentahoSession.class );
   SimpleReportingComponent component = mock( SimpleReportingComponent.class );
   AsyncJobFileStagingHandler handler = mock( AsyncJobFileStagingHandler.class );
-  IFixedSizeStreamingContent input =
-    new AsyncJobFileStagingHandler.FixedSizeStagingContent( new NullInputStream( 0 ), 0 );
+  IFixedSizeStreamingContent input;
 
   MasterReport report = mock( MasterReport.class );
   ModifiableConfiguration configuration = mock( ModifiableConfiguration.class );
@@ -67,6 +67,9 @@ public class PentahoAsyncExecutionTest {
     PentahoSessionHolder.removeSession();
 
     PentahoSessionHolder.setSession( userSession );
+
+    File temp = File.createTempFile( "junit", "tmp" );
+    input = new AsyncJobFileStagingHandler.FixedSizeStagingContent( temp );
 
     when( handler.getStagingContent() ).thenReturn( input );
     when( report.getReportConfiguration() ).thenReturn( configuration );

--- a/test-src/org/pentaho/reporting/platform/plugin/staging/AsyncJobFileStagingHandlerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/staging/AsyncJobFileStagingHandlerTest.java
@@ -28,9 +28,15 @@ import org.pentaho.platform.api.engine.IApplicationContext;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -72,6 +78,8 @@ public class AsyncJobFileStagingHandlerTest {
     session = mock( IPentahoSession.class );
     when( session.getId() ).thenReturn( SESSION_ID );
     rand.nextBytes( data );
+
+    AsyncJobFileStagingHandler.cleanStagingDir();
   }
 
   @Test public void testWriteToCorrectDestinationTest() throws IOException {
@@ -103,26 +111,34 @@ public class AsyncJobFileStagingHandlerTest {
     // this simulate when result is response output stream
     // so we just copy data from staged file into response stream
     IFixedSizeStreamingContent input = handler.getStagingContent();
-    byte[] result = IOUtils.toByteArray( input.getStream() );
+    InputStream in = input.getStream();
+
+    byte[] result = IOUtils.toByteArray( in );
+
+    IOUtils.closeQuietly( in );
 
     assertArrayEquals( "byte wise read an writes", data, result );
 
-    // this is custom input stream
-    // call to input.close() will delete temp staging file
-    // in normal situation copy utility is responsible for calling close.
-    input.getStream().close();
-
-    assertFalse( "File deleted after input stream get closed", tempFile.exists() );
+    assertTrue( "File not get deleted after input stream get closed", tempFile.exists() );
     assertTrue( "temp dir is not deleted", tempDir.toFile().exists() );
+
+    assertTrue( input.cleanContent() );
+
+    assertFalse( "File got deleted explicitly", tempFile.exists() );
   }
 
-  @Test public void testStagingDirNotGetDeletedBetweenExecutions() throws IOException, InterruptedException {
+  @Test public void testStagingDirNotGetDeletedBetweenExecutions() throws Exception {
     CountDownLatch startSignal = new CountDownLatch( 0 );
 
     int count = 30;
     ExecutorService service = Executors.newFixedThreadPool( count );
+
+    List<AsyncJobFileStagingHandler> handlers = new ArrayList<>();
+
     for ( int i = 0 ; i < count; i++ ) {
-      service.submit( new AsyncStagingReadWrite( startSignal, new AsyncJobFileStagingHandler( session ) ) );
+      AsyncJobFileStagingHandler handler = new AsyncJobFileStagingHandler( session );
+      handlers.add( handler );
+      service.submit( new AsyncStagingReadWrite( startSignal, handler ) );
     }
 
     startSignal.countDown();
@@ -132,13 +148,18 @@ public class AsyncJobFileStagingHandlerTest {
     Path stagingDir = AsyncJobFileStagingHandler.getStagingDirPath();
     File[] fileList = stagingDir.toFile().listFiles();
 
-    assertEquals( "Only one folder", 1, fileList.length );
-
     File sessionFolder = fileList[0];
     assertTrue( sessionFolder.isDirectory() );
 
     assertEquals( "Folder is named by session id", session.getId(), sessionFolder.getName() );
-    assertEquals( "Folder is empty", 0, sessionFolder.list().length );
+
+    assertEquals( "Folder is NOT empty after a BACKLOG-7598 fix", 30, sessionFolder.list().length );
+
+    for ( AsyncJobFileStagingHandler handler : handlers ) {
+      assertTrue( handler.getStagingContent().cleanContent() );
+    }
+
+    assertEquals("Staging folder empty now", 0, sessionFolder.list().length );
   }
 
   static class AsyncStagingReadWrite implements Runnable {
@@ -151,24 +172,36 @@ public class AsyncJobFileStagingHandlerTest {
       this.handler = handler;
     }
 
+    /**
+     * Leak of Input/Output stream will prevent test
+     * from success results since as far as streams is
+     * open file can't be deleted successfully.
+     *
+     */
     @Override public void run() {
+      OutputStream out = null;
+      InputStream in = null;
+
       try {
         startSignal.await();
         // write to
-        OutputStream out = handler.getStagingOutputStream();
+        out = handler.getStagingOutputStream();
         IOUtils.copy( new ByteArrayInputStream( data, 0, data.length ), out );
+        out.flush();
         out.close();
 
         // read from
         IFixedSizeStreamingContent input = handler.getStagingContent();
-        byte[] result = IOUtils.toByteArray( input.getStream() );
+        in = input.getStream();
+        byte[] result = IOUtils.toByteArray( in );
 
         assertArrayEquals( "byte wise read an writes", data, result );
 
-        // close input stream, implicitly delete staging file.
-        input.getStream().close();
       } catch ( Exception e ) {
         fail( "Unexpected exception: " + e.getClass().getName() );
+      } finally {
+        IOUtils.closeQuietly( out );
+        IOUtils.closeQuietly( in );
       }
     }
   }


### PR DESCRIPTION
This brings next fixes for us:
1) We need a special endpoint for pdf viewer plugin now able to send get
request to whatever it want it to send. Since we can't fix chrome, we have
to fix JobManager fot that.

2) We need to keep same content between requests.
So since we expected to keep content we don't clean-up future after
content requested. Instead - we keep a collection of futures. We expect
clean-up when session destroyed. Also content is kept in staging folder.

3) Since we keep content - we introduce new methods for
IFixedSizeStreamingContent.cleanContent() to explicitly clean up content.

And yes - finally we came to a one-more cahce layer - all content is kept in
statging folder during server works.

Pay attention - content for all currently running sessions.