### PR TITLE
[BACKLOG-6745] - enchase perfomance logging with additional info

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/AuditWrapper.java
+++ b/src/org/pentaho/reporting/platform/plugin/AuditWrapper.java
@@ -1,0 +1,48 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin;
+
+import org.pentaho.platform.api.engine.ILogger;
+import org.pentaho.platform.engine.core.audit.AuditHelper;
+
+/**
+ * Wrapper to a static AuditHelper call. Simplify mocking and get rid of static dependencies in main code.
+ */
+public class AuditWrapper {
+
+  public static final AuditWrapper NULL = new NullAudtitWrapper();
+
+  public void audit( String instanceId, final String userId, String actionName, final String objectType,
+                     String processId, final String messageType, final String message, final String value, final float duration,
+                     final ILogger logger ) {
+    // register execution attempt
+    AuditHelper.audit( instanceId, userId, actionName, objectType, processId,
+      messageType, message, value, duration, logger );
+  }
+
+  public static class NullAudtitWrapper extends AuditWrapper {
+
+    @Override
+    public void audit( String instanceId, final String userId, String actionName, final String objectType,
+                       String processId, final String messageType, final String message, final String value, final float duration,
+                       final ILogger logger ) {
+      // no op
+    }
+  }
+}

--- a/src/org/pentaho/reporting/platform/plugin/ExecuteReportContentHandler.java
+++ b/src/org/pentaho/reporting/platform/plugin/ExecuteReportContentHandler.java
@@ -40,6 +40,7 @@ import org.pentaho.reporting.engine.classic.core.AttributeNames;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.html.HtmlTableModule;
 import org.pentaho.reporting.engine.classic.core.util.StagingMode;
+import org.pentaho.reporting.platform.plugin.async.ReportListenerThreadHolder;
 import org.pentaho.reporting.platform.plugin.messages.Messages;
 import org.pentaho.reporting.platform.plugin.staging.AbstractStagingHandler;
 import org.pentaho.reporting.platform.plugin.staging.StagingHandler;
@@ -60,9 +61,12 @@ public class ExecuteReportContentHandler {
 
   public void createReportContent( final OutputStream outputStream, final Serializable fileId, final String path,
       final boolean forceDefaultOutputTarget ) throws Exception {
+    ReportListenerThreadHolder.setRequestId( contentGenerator.getInstanceId() );
+
     final long start = System.currentTimeMillis();
     final Map<String, Object> inputs = contentGenerator.createInputs();
 
+    // Deprecated call. See AuditWrapper.
     AuditHelper.audit( userSession.getId(), userSession.getName(), path, contentGenerator.getObjectName(), getClass()
         .getName(), MessageTypes.INSTANCE_START, contentGenerator.getInstanceId(), "", 0, contentGenerator ); //$NON-NLS-1$
 

--- a/src/org/pentaho/reporting/platform/plugin/ParameterContentGenerator.java
+++ b/src/org/pentaho/reporting/platform/plugin/ParameterContentGenerator.java
@@ -33,6 +33,7 @@ import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.engine.core.solution.SimpleParameterProvider;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.services.solution.SimpleContentGenerator;
+import org.pentaho.reporting.platform.plugin.async.ReportListenerThreadHolder;
 
 public class ParameterContentGenerator extends SimpleContentGenerator {
   /**
@@ -43,6 +44,9 @@ public class ParameterContentGenerator extends SimpleContentGenerator {
 
   @Override
   public void createContent( OutputStream outputStream ) throws Exception {
+    // set instance Id if debug is enabled.
+    ReportListenerThreadHolder.setRequestId( this.instanceId );
+
     final IParameterProvider requestParams = getRequestParameters();
 
     RepositoryFile prptFile = resolvePrptFile( requestParams );

--- a/src/org/pentaho/reporting/platform/plugin/PluginPerfomanceMonitorContext.java
+++ b/src/org/pentaho/reporting/platform/plugin/PluginPerfomanceMonitorContext.java
@@ -1,0 +1,72 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin;
+
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.reporting.engine.classic.core.states.PerformanceMonitorContext;
+import org.pentaho.reporting.libraries.base.util.LoggingStopWatch;
+import org.pentaho.reporting.libraries.base.util.PerformanceLoggingStopWatch;
+import org.pentaho.reporting.platform.plugin.async.ReportListenerThreadHolder;
+
+import javax.swing.event.ChangeListener;
+
+/**
+ * Created by dima.prokopenko@gmail.com on 4/19/2016.
+ */
+public class PluginPerfomanceMonitorContext implements PerformanceMonitorContext {
+
+  public static final String FORMAT = "%1s sessionid[%2s] userid[%3s] requestid[%4s]";
+
+  @Override public PerformanceLoggingStopWatch createStopWatch( String tag ) {
+    return new LoggingStopWatch( tag, getMessage( null ) );
+  }
+
+  @Override public PerformanceLoggingStopWatch createStopWatch( String tag, Object message ) {
+    return new LoggingStopWatch( tag, getMessage( String.valueOf( message ) ) );
+  }
+
+  private String getMessage( String message ) {
+    IPentahoSession session = PentahoSessionHolder.getSession();
+    String sessionId = null;
+    String name = null;
+
+    if ( session != null ) {
+      sessionId = session.getId();
+      name = session.getName();
+    }
+
+    String requestId = ReportListenerThreadHolder.getRequestId();
+    message = String.format( FORMAT, message, sessionId, name, requestId );
+
+    return message;
+  }
+
+  @Override public void addChangeListener( ChangeListener listener ) {
+    // sorry, no.
+  }
+
+  @Override public void removeChangeListener( ChangeListener listener ) {
+    // sorry, no.
+  }
+
+  @Override public void close() {
+    // have not idea what to do with that.
+  }
+}

--- a/src/org/pentaho/reporting/platform/plugin/async/AbstractAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AbstractAsyncReportExecution.java
@@ -5,9 +5,9 @@ import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.platform.api.engine.IPentahoSession;
-import org.pentaho.platform.engine.core.audit.AuditHelper;
 import org.pentaho.platform.engine.core.audit.MessageTypes;
 import org.pentaho.reporting.libraries.base.util.ArgumentNullException;
+import org.pentaho.reporting.platform.plugin.AuditWrapper;
 import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
 import org.pentaho.reporting.platform.plugin.staging.IFixedSizeStreamingContent;
@@ -16,7 +16,7 @@ import java.io.InputStream;
 import java.util.UUID;
 
 public abstract class AbstractAsyncReportExecution<TReportState extends IAsyncReportState>
-  implements IAsyncReportExecution<TReportState>, IListenableFutureDelegator<IFixedSizeStreamingContent>  {
+  implements IAsyncReportExecution<TReportState>, IListenableFutureDelegator<IFixedSizeStreamingContent> {
 
   protected final SimpleReportingComponent reportComponent;
   protected final AsyncJobFileStagingHandler handler;
@@ -28,13 +28,8 @@ public abstract class AbstractAsyncReportExecution<TReportState extends IAsyncRe
 
   private static final Log log = LogFactory.getLog( AbstractAsyncReportExecution.class );
 
-  /**
-   * Creates callable execuiton task.
-   *
-   * @param url             for audit purposes
-   * @param reportComponent component responsible for gererating report
-   * @param handler         content staging handler between requests
-   */
+  private AuditWrapper audit;
+
   public AbstractAsyncReportExecution( final String url,
                                        final SimpleReportingComponent reportComponent,
                                        final AsyncJobFileStagingHandler handler,
@@ -45,6 +40,31 @@ public abstract class AbstractAsyncReportExecution<TReportState extends IAsyncRe
     this.url = url;
     this.auditId = auditId;
     this.safeSession = safeSession;
+    this.audit = AuditWrapper.NULL;
+  }
+
+  /**
+   * Creates callable execuiton task.
+   *
+   * @param url             for audit purposes
+   * @param reportComponent component responsible for gererating report
+   * @param handler         content staging handler between requests
+   * @param safeSession     pentaho session used mostly for log/audit purposes
+   * @param auditId         audit id per execution. Typically nested from http controller that do create this task
+   * @param audit           audit record handler implementation
+   */
+  public AbstractAsyncReportExecution( final String url,
+                                       final SimpleReportingComponent reportComponent,
+                                       final AsyncJobFileStagingHandler handler,
+                                       final IPentahoSession safeSession,
+                                       final String auditId,
+                                       final AuditWrapper audit ) {
+    this.reportComponent = reportComponent;
+    this.handler = handler;
+    this.url = url;
+    this.auditId = auditId;
+    this.safeSession = safeSession;
+    this.audit = audit;
   }
 
   public void notifyTaskQueued( final UUID id ) {
@@ -60,12 +80,16 @@ public abstract class AbstractAsyncReportExecution<TReportState extends IAsyncRe
     return this.listener;
   }
 
+  protected AuditWrapper getAudit() {
+    return this.audit;
+  }
+
   protected void fail() {
     // do not erase canceled status
     if ( listener != null && !listener.getState().getStatus().equals( AsyncExecutionStatus.CANCELED ) ) {
       listener.setStatus( AsyncExecutionStatus.FAILED );
     }
-    AuditHelper.audit( safeSession.getId(), safeSession.getId(), url, getClass().getName(), getClass().getName(),
+    audit.audit( safeSession.getId(), safeSession.getName(), url, getClass().getName(), getClass().getName(),
       MessageTypes.FAILED, auditId, "", 0, null );
   }
 

--- a/src/org/pentaho/reporting/platform/plugin/async/ReportListenerThreadHolder.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/ReportListenerThreadHolder.java
@@ -22,6 +22,7 @@ public class ReportListenerThreadHolder {
 
   private static final ThreadLocal<IAsyncReportListener> listenerThreadLocal =
     new ThreadLocal<>();
+  private static final ThreadLocal<String> auditIdLocal = new ThreadLocal<>();
 
   public static IAsyncReportListener getListener() {
     return listenerThreadLocal.get();
@@ -31,8 +32,17 @@ public class ReportListenerThreadHolder {
     listenerThreadLocal.set( listener );
   }
 
+  public static void setRequestId( final String requestId ) {
+    auditIdLocal.set( requestId );
+  }
+
+  public static String getRequestId() {
+    return auditIdLocal.get();
+  }
+
   public static void clear() {
     listenerThreadLocal.remove();
+    auditIdLocal.remove();
   }
 
 }

--- a/test-src/org/pentaho/reporting/platform/plugin/BackgroundJobContentGeneratorTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/BackgroundJobContentGeneratorTest.java
@@ -1,0 +1,264 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IApplicationContext;
+import org.pentaho.platform.api.engine.IParameterProvider;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.engine.ObjectFactoryException;
+import org.pentaho.platform.engine.core.audit.MessageTypes;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.html.HtmlTableModule;
+import org.pentaho.reporting.platform.plugin.async.IAsyncReportExecution;
+import org.pentaho.reporting.platform.plugin.async.IAsyncReportState;
+import org.pentaho.reporting.platform.plugin.async.IPentahoAsyncExecutor;
+import org.pentaho.reporting.platform.plugin.async.PentahoAsyncExecutor;
+import org.pentaho.reporting.platform.plugin.async.ReportListenerThreadHolder;
+import org.pentaho.reporting.platform.plugin.staging.IFixedSizeStreamingContent;
+import org.pentaho.test.platform.engine.core.SimpleObjectFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test basic functionality and audit usage.
+ * <p>
+ * Created by dima.prokopenko@gmail.com on 4/21/2016.
+ */
+public class BackgroundJobContentGeneratorTest {
+
+  public static final String instanceId = "instanceId";
+  public static final String sessionId = "sessionId";
+  public static final String sessionName = "junitName";
+  public static final String path = "junitPath";
+  public static final String fieldId = "junitFieldId";
+
+  public static final UUID uuid = UUID.randomUUID();
+
+  IApplicationContext appContext = mock( IApplicationContext.class );
+  SimpleObjectFactory factory = new SimpleObjectFactory();
+  SimpleReportingComponent component = mock( SimpleReportingComponent.class );
+
+  IPentahoSession session = mock( IPentahoSession.class );
+  IParameterProvider paramProvider = mock( IParameterProvider.class );
+  HttpServletResponse httpResponse = mock( HttpServletResponse.class );
+
+  Map<String, IParameterProvider> parameterProviders;
+
+  @Before
+  public void before() throws ObjectFactoryException {
+    Path customStaging =
+      Paths.get( System.getProperty( "java.io.tmpdir" ), BackgroundJobContentGeneratorTest.class.getSimpleName() );
+
+    when( appContext.getSolutionPath( anyString() ) ).thenReturn( customStaging.toString() );
+
+    //register mock executor to not execute anything
+    factory.defineObject( PentahoAsyncExecutor.BEAN_NAME, MockPentahoAsyncExecutor.class.getName() );
+
+    PentahoSystem.setApplicationContext( appContext );
+    PentahoSystem.registerPrimaryObjectFactory( factory );
+
+    when( session.getId() ).thenReturn( sessionId );
+    when( session.getName() ).thenReturn( sessionName );
+
+    parameterProviders = new HashMap<>();
+    parameterProviders.put( "path", paramProvider );
+    when( paramProvider.getParameter( "httpresponse" ) ).thenReturn( httpResponse );
+  }
+
+  @Test
+  public void testSuccessExecutionAudit() throws Exception {
+    BackgroundJobReportContentGenerator generator = spy( new BackgroundJobReportContentGenerator() );
+    generator.setParameterProviders( parameterProviders );
+    generator.setSession( session );
+    generator.setInstanceId( instanceId );
+
+    when( component.validate() ).thenReturn( true );
+
+    AuditWrapper wrapper = mock( AuditWrapper.class );
+
+    generator.createReportContent( fieldId, path, component, wrapper );
+
+    // execution attempt registered
+    verify( wrapper, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( generator.getClass().getName() ),
+      eq( generator.getClass().getName() ),
+      eq( MessageTypes.EXECUTION ),
+      eq( instanceId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( generator )
+    );
+
+    verify( generator, times( 0 ) ).sendErrorResponse();
+    verify( generator, times( 1 ) ).sendSuccessRedirect( eq( uuid ) );
+
+    verify( httpResponse ).sendRedirect( eq( BackgroundJobReportContentGenerator.REDIRECT_PREFIX + uuid.toString()
+      + BackgroundJobReportContentGenerator.REDIRECT_POSTFIX ) );
+
+    assertEquals( "BACKLOG-6745", instanceId, ReportListenerThreadHolder.getRequestId() );
+
+  }
+
+  @Test
+  public void testFailedExecutionAudit() throws Exception {
+    BackgroundJobReportContentGenerator generator = spy( new BackgroundJobReportContentGenerator() );
+    generator.setParameterProviders( parameterProviders );
+    generator.setSession( session );
+    generator.setInstanceId( instanceId );
+
+    // validation will not pass
+    when( component.validate() ).thenReturn( false );
+
+    AuditWrapper wrapper = mock( AuditWrapper.class );
+
+    generator.createReportContent( fieldId, path, component, wrapper );
+
+    // execution attempt registered
+    verify( wrapper, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( generator.getClass().getName() ),
+      eq( generator.getClass().getName() ),
+      eq( MessageTypes.EXECUTION ),
+      eq( instanceId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( generator )
+    );
+
+    // then fail registered also.
+    verify( wrapper, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( generator.getClass().getName() ),
+      eq( generator.getClass().getName() ),
+      eq( MessageTypes.FAILED ),
+      eq( instanceId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( generator )
+    );
+
+    verify( generator, times( 0 ) ).sendSuccessRedirect( any( UUID.class ) );
+    verify( generator, times( 1 ) ).sendErrorResponse();
+  }
+
+  @Test
+  public void testSimpleReportingComponentInitialized() throws Exception {
+    BackgroundJobReportContentGenerator generator = spy( new BackgroundJobReportContentGenerator() );
+    generator.setParameterProviders( parameterProviders );
+    generator.setSession( session );
+    generator.setInstanceId( instanceId );
+    when( component.validate() ).thenReturn( true );
+    AuditWrapper wrapper = mock( AuditWrapper.class );
+
+    generator.createReportContent( fieldId, path, component, wrapper );
+
+    verify( component, times( 1 ) ).setReportFileId( eq( fieldId ) );
+    verify( component, times( 0 ) ).setReportDefinitionPath( anyString() );
+    verify( component, times( 0 ) ).setReportDefinitionInputStream( any( InputStream.class ) );
+
+    verify( component, times( 1 ) ).setPaginateOutput( eq( true ) );
+    verify( component, times( 1 ) ).setForceDefaultOutputTarget( eq( false ) );
+    verify( component, times( 1 ) ).setDefaultOutputTarget( eq( HtmlTableModule.TABLE_HTML_PAGE_EXPORT_TYPE ) );
+
+    // this is not a prpti report
+    verify( component, times( 0 ) ).setForceUnlockPreferredOutput( anyBoolean() );
+  }
+
+  @Test
+  public void testSimpleReportingComponentInitializedPrpti() throws Exception {
+    BackgroundJobReportContentGenerator generator = spy( new BackgroundJobReportContentGenerator() );
+    generator.setParameterProviders( parameterProviders );
+    generator.setSession( session );
+    generator.setInstanceId( instanceId );
+    when( component.validate() ).thenReturn( true );
+    AuditWrapper wrapper = mock( AuditWrapper.class );
+
+    // we determine prpti report by the enc of the string
+    generator.createReportContent( fieldId, path + ".prpti", component, wrapper );
+
+    verify( component, times( 1 ) ).setReportFileId( eq( fieldId ) );
+    verify( component, times( 0 ) ).setReportDefinitionPath( anyString() );
+    verify( component, times( 0 ) ).setReportDefinitionInputStream( any( InputStream.class ) );
+
+    verify( component, times( 1 ) ).setPaginateOutput( eq( true ) );
+    verify( component, times( 1 ) ).setForceDefaultOutputTarget( eq( false ) );
+    verify( component, times( 1 ) ).setDefaultOutputTarget( eq( HtmlTableModule.TABLE_HTML_PAGE_EXPORT_TYPE ) );
+
+    // this is prpti report
+    verify( component, times( 1 ) ).setForceUnlockPreferredOutput( eq( true ) );
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    PentahoSystem.shutdown();
+  }
+
+  /**
+   * We can't use mock for this class. Since we obtain it through pentaho factory - it should be public available class,
+   * not a particular mocked object.
+   */
+  public static class MockPentahoAsyncExecutor implements IPentahoAsyncExecutor {
+
+    @Override public Future<IFixedSizeStreamingContent> getFuture( UUID id, IPentahoSession session ) {
+      return null;
+    }
+
+    @Override public void cleanFuture( UUID id, IPentahoSession session ) {
+
+    }
+
+    @Override public UUID addTask( IAsyncReportExecution task, IPentahoSession session ) {
+      return uuid;
+    }
+
+    @Override public IAsyncReportState getReportState( UUID id, IPentahoSession session ) {
+      return null;
+    }
+
+    @Override public void requestPage( UUID id, IPentahoSession session, int page ) {
+
+    }
+
+    @Override public void schedule( UUID uuid, IPentahoSession session ) {
+
+    }
+  }
+}

--- a/test-src/org/pentaho/reporting/platform/plugin/ExecuteReportContentHandlerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/ExecuteReportContentHandlerTest.java
@@ -1,0 +1,676 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IParameterProvider;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.api.locale.IPentahoLocale;
+import org.pentaho.platform.api.repository2.unified.IRepositoryFileData;
+import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
+import org.pentaho.platform.api.repository2.unified.RepositoryFile;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAce;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileAcl;
+import org.pentaho.platform.api.repository2.unified.RepositoryFilePermission;
+import org.pentaho.platform.api.repository2.unified.RepositoryFileTree;
+import org.pentaho.platform.api.repository2.unified.RepositoryRequest;
+import org.pentaho.platform.api.repository2.unified.VersionSummary;
+import org.pentaho.platform.engine.core.audit.MessageTypes;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.reporting.engine.classic.core.AttributeNames;
+import org.pentaho.reporting.engine.classic.core.MasterReport;
+import org.pentaho.reporting.engine.classic.core.modules.output.table.html.HtmlTableModule;
+import org.pentaho.reporting.engine.classic.core.util.StagingMode;
+import org.pentaho.reporting.libraries.resourceloader.ResourceException;
+import org.pentaho.reporting.platform.plugin.messages.Messages;
+import org.pentaho.test.platform.engine.core.SimpleObjectFactory;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests ExecuteContentHandler.createReportContent(...) katamari code.
+ * <p>
+ * Created by dima.prokopenko@gmail.com on 4/26/2016.
+ */
+public class ExecuteReportContentHandlerTest {
+
+  private static final String sessionId = "sessionId_09";
+  private static final String sessionName = "junitName_90";
+  private static final String fileId = "junit F id";
+  private static final String path = "some/path.prpt";
+  private static final String instanceId = UUID.randomUUID().toString();
+
+  private ReportContentGenerator contentGenerator = mock( ReportContentGenerator.class );
+  private IPentahoSession session = mock( IPentahoSession.class );
+  private OutputStream outputStream = mock( OutputStream.class );
+  private SimpleReportingComponent reportComponent = mock( SimpleReportingComponent.class );
+  private AuditWrapper audit = mock( AuditWrapper.class );
+
+  private HttpServletResponse response = mock( HttpServletResponse.class );
+  private IParameterProvider prameterProvider = mock( IParameterProvider.class );
+  private Map<String, IParameterProvider> providersMap = new HashMap<>();
+
+  private static SimpleObjectFactory factory = new SimpleObjectFactory();
+
+  private static RepositoryFile file = mock( RepositoryFile.class );
+  private static String fileName = "/someFile.prpt";
+
+  private MasterReport report = mock( MasterReport.class );
+
+  private Map<String, Object> inputs = new HashMap<>();
+
+  @BeforeClass
+  public static void beforeClass() {
+    // define mock repository which will return mocked files
+    factory.defineObject( IUnifiedRepository.class.getSimpleName(), MockUnifiedRepository.class.getName() );
+    PentahoSystem.registerPrimaryObjectFactory( factory );
+
+    when( file.getName() ).thenReturn( fileName );
+  }
+
+  @Before
+  public void before() throws IOException, ResourceException {
+    when( session.getId() ).thenReturn( sessionId );
+    when( session.getName() ).thenReturn( sessionName );
+    when( contentGenerator.getUserSession() ).thenReturn( session );
+
+    // set test staging mode:
+    inputs.put( "report-staging-mode", StagingMode.THRU );
+
+    when( contentGenerator.createInputs() ).thenReturn( inputs );
+
+    // set report mime type
+    when( reportComponent.getMimeType() ).thenReturn( "text/html" );
+
+    providersMap.put( "path", prameterProvider );
+    when( prameterProvider.getParameter( eq( "httpresponse" ) ) ).thenReturn( response );
+    when( contentGenerator.getParameterProviders() ).thenReturn( providersMap );
+    when( contentGenerator.getInstanceId() ).thenReturn( instanceId );
+    when( contentGenerator.getObjectName() ).thenReturn( ReportContentGenerator.class.getName() );
+  }
+
+  /**
+   * should audit success when report validated AND executed.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testSuccessExecutionAudit() throws Exception {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    when( reportComponent.validate() ).thenReturn( true );
+    when( reportComponent.execute() ).thenReturn( true );
+
+    handler.createReportContent( outputStream, fileId, path, true, reportComponent, audit );
+
+    // execution attempt registered
+    verify( audit, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( ReportContentGenerator.class.getName() ),
+      eq( handler.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_START ),
+      eq( instanceId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( contentGenerator )
+    );
+
+    verify( audit, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( ReportContentGenerator.class.getName() ),
+      eq( handler.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_END ),
+      eq( instanceId ),
+      eq( "" ),
+      anyFloat(),
+      eq( contentGenerator )
+    );
+  }
+
+  /**
+   * validation failed and execution even not started.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testFailedValidationAudit() throws Exception {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    when( reportComponent.validate() ).thenReturn( false );
+
+    when( reportComponent.execute() )
+      .thenThrow( new Exception( "execution should not be called if valiedation failed" ) );
+
+    handler.createReportContent( outputStream, fileId, path, true, reportComponent, audit );
+
+    verify( audit, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( ReportContentGenerator.class.getName() ),
+      eq( handler.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_START ),
+      eq( instanceId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( contentGenerator )
+    );
+
+    verify( audit, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( ReportContentGenerator.class.getName() ),
+      eq( handler.getClass().getName() ),
+      eq( MessageTypes.FAILED ),
+      eq( instanceId ),
+      eq( "" ),
+      anyFloat(),
+      eq( contentGenerator )
+    );
+  }
+
+  /**
+   * validation passed but execution failed.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testFailedExecutionAudit() throws Exception {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    when( reportComponent.validate() ).thenReturn( true );
+
+    when( reportComponent.execute() ).thenReturn( false );
+
+    handler.createReportContent( outputStream, fileId, path, true, reportComponent, audit );
+
+    verify( audit, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( ReportContentGenerator.class.getName() ),
+      eq( handler.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_START ),
+      eq( instanceId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( contentGenerator )
+    );
+
+    verify( audit, times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( path ),
+      eq( ReportContentGenerator.class.getName() ),
+      eq( handler.getClass().getName() ),
+      eq( MessageTypes.FAILED ),
+      eq( instanceId ),
+      eq( "" ),
+      anyFloat(),
+      eq( contentGenerator )
+    );
+  }
+
+
+  /**
+   * Tests basic actions for report component when create normal report.
+   */
+  @Test
+  public void testCreateReportContentReportComponent1() throws Exception {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    // validated and executed.
+    when( reportComponent.validate() ).thenReturn( true );
+    when( reportComponent.execute() ).thenReturn( true );
+
+    // simulate pagable html.
+    when( reportComponent.getComputedOutputTarget() ).thenReturn( HtmlTableModule.TABLE_HTML_PAGE_EXPORT_TYPE );
+
+    inputs.remove( ParameterXmlContentHandler.SYS_PARAM_SESSION_ID );
+
+    boolean force = false;
+
+    handler.createReportContent( outputStream, fileId, path, force, reportComponent, audit );
+
+    assertNotNull( "always have sys param session Id set.",
+      inputs.get( ParameterXmlContentHandler.SYS_PARAM_SESSION_ID ) );
+
+    // report component initialized:
+    verify( reportComponent, times( 1 ) ).setReportFileId( eq( fileId ) );
+    verify( reportComponent, times( 1 ) ).setPaginateOutput( eq( true ) );
+    verify( reportComponent, times( 1 ) ).setForceDefaultOutputTarget( force );
+
+    // do override this value only for prpti reports, not for prpt.
+    verify( reportComponent, times( 0 ) ).setForceUnlockPreferredOutput( anyBoolean() );
+    verify( reportComponent, times( 1 ) ).setInputs( eq( inputs ) );
+
+    // finally we obtain MasterReport from report component
+    verify( reportComponent, times( 1 ) ).getReport();
+
+    // we do set output stream to report component - for THRU it is wrapped servlet output stream
+    verify( reportComponent, times( 1 ) ).setOutputStream( any( OutputStream.class ) );
+
+    verify( reportComponent, times( 1 ) ).getMimeType();
+  }
+
+  /**
+   * Test response headers set for successfull execution
+   */
+  @Test
+  public void setSuccessHeadersTest() throws Exception {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    // validated and executed.
+    when( reportComponent.validate() ).thenReturn( true );
+    when( reportComponent.execute() ).thenReturn( true );
+
+    handler.createReportContent( outputStream, fileId, path, true, reportComponent, audit );
+
+    // since this is successfull report execution check for response headers set:
+    verify( response, times( 1 ) )
+      .setHeader( eq( "Content-Disposition" ), eq( "inline; filename*=UTF-8''%3AsomeFile.html" ) );
+    verify( response, times( 1 ) ).setHeader( eq( "Content-Description" ), eq( fileName ) );
+    verify( response, times( 1 ) ).setHeader( eq( "Cache-Control" ), eq( "private, max-age=0, must-revalidate" ) );
+    verify( response, times( 1 ) ).setContentLength( anyInt() );
+
+    // we don't flush or close servlet output stream manually:
+    verify( outputStream, times( 0 ) ).flush();
+    verify( outputStream, times( 0 ) ).close();
+
+  }
+
+  @Test
+  public void setFailedHeadersTest() throws Exception {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    // validated and executed.
+    when( reportComponent.validate() ).thenReturn( true );
+    when( reportComponent.execute() ).thenReturn( false );
+
+    handler.createReportContent( outputStream, fileId, path, true, reportComponent, audit );
+
+    // headers set in any case:
+    verify( response, times( 1 ) )
+      .setHeader( eq( "Content-Disposition" ), eq( "inline; filename*=UTF-8''%3AsomeFile.html" ) );
+    verify( response, times( 1 ) ).setHeader( eq( "Content-Description" ), eq( fileName ) );
+    verify( response, times( 1 ) ).setHeader( eq( "Cache-Control" ), eq( "private, max-age=0, must-revalidate" ) );
+
+    // sepcific for failed attempt:
+    verify( response, times( 1 ) ).setStatus( eq( HttpServletResponse.SC_INTERNAL_SERVER_ERROR ) );
+
+    // this is famous 'Sorry, we really did try'
+    verify( outputStream, times( 1 ) )
+      .write( Messages.getInstance().getString( "ReportPlugin.ReportValidationFailed" ).getBytes() );
+
+    // oh we don't close output stream, but do a flush:
+    verify( outputStream, times( 1 ) ).flush();
+    verify( outputStream, times( 0 ) ).close();
+  }
+
+  /**
+   * Check staging mode applied when passed as parameter
+   */
+  @Test
+  public void testGetStagingModeFromInputs() {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    // we have set default value to THRU
+    StagingMode mode = (StagingMode) inputs.get( "report-staging-mode" );
+    assertEquals( StagingMode.THRU, mode );
+
+    mode = handler.getStagingMode( inputs, report );
+    assertEquals( StagingMode.THRU, mode );
+
+    inputs.put( "report-staging-mode", StagingMode.MEMORY );
+
+    mode = handler.getStagingMode( inputs, report );
+    assertEquals( StagingMode.MEMORY, mode );
+  }
+
+  /**
+   * Staging mode set as attribute for MasterReport
+   */
+  @Test
+  public void testGetStagingHandlerFromReport() {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    // no mode from inputs
+    inputs.remove( "report-staging-mode" );
+    // staging mode set as a field for report:
+    when( report.getAttribute(
+      eq( AttributeNames.Pentaho.NAMESPACE ),
+      eq( AttributeNames.Pentaho.STAGING_MODE ) )
+    ).thenReturn( StagingMode.TMPFILE );
+
+    StagingMode mode = handler.getStagingMode( inputs, report );
+
+    assertEquals( StagingMode.TMPFILE, mode );
+  }
+
+  /**
+   * Staging mode default if no request, no report definition, neither PentahoSystem.globalProperties does not contains
+   * such values.
+   */
+  @Test
+  public void testGetStagingModeDefault() {
+    final ExecuteReportContentHandler handler = new ExecuteReportContentHandler( contentGenerator );
+
+    // no mode from inputs, no from report (since we don't mock it directly)
+    inputs.remove( "report-staging-mode" );
+
+    StagingMode mode = handler.getStagingMode( inputs, report );
+
+    assertEquals( StagingMode.THRU, mode );
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    PentahoSystem.shutdown();
+  }
+
+  /**
+   * A huge class mock to be used for pentaho factory. :(
+   */
+  public static class MockUnifiedRepository implements IUnifiedRepository {
+
+    @Override public RepositoryFile getFile( String path ) {
+      return null;
+    }
+
+    @Override public RepositoryFileTree getTree( String path, int depth, String filter, boolean showHidden ) {
+      return null;
+    }
+
+    @Override public RepositoryFileTree getTree( RepositoryRequest repositoryRequest ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFileAtVersion( Serializable fileId, Serializable versionId ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFileById( Serializable fileId ) {
+      return file;
+    }
+
+    @Override public RepositoryFile getFile( String path, boolean loadLocaleMaps ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFileById( Serializable fileId, boolean loadLocaleMaps ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFile( String path, IPentahoLocale locale ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFileById( Serializable fileId, IPentahoLocale locale ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFile( String path, boolean loadLocaleMaps, IPentahoLocale locale ) {
+      return null;
+    }
+
+    @Override public RepositoryFile getFileById( Serializable fileId, boolean loadLocaleMaps, IPentahoLocale locale ) {
+      return null;
+    }
+
+    @Override public <T extends IRepositoryFileData> T getDataForRead( Serializable fileId, Class<T> dataClass ) {
+      return null;
+    }
+
+    @Override
+    public <T extends IRepositoryFileData> T getDataAtVersionForRead( Serializable fileId, Serializable versionId,
+                                                                      Class<T> dataClass ) {
+      return null;
+    }
+
+    @Override public <T extends IRepositoryFileData> T getDataForExecute( Serializable fileId, Class<T> dataClass ) {
+      return null;
+    }
+
+    @Override
+    public <T extends IRepositoryFileData> T getDataAtVersionForExecute( Serializable fileId, Serializable versionId,
+                                                                         Class<T> dataClass ) {
+      return null;
+    }
+
+    @Override public <T extends IRepositoryFileData> List<T> getDataForReadInBatch( List<RepositoryFile> files,
+                                                                                    Class<T> dataClass ) {
+      return null;
+    }
+
+    @Override public <T extends IRepositoryFileData> List<T> getDataForExecuteInBatch( List<RepositoryFile> files,
+                                                                                       Class<T> dataClass ) {
+      return null;
+    }
+
+    @Override
+    public RepositoryFile createFile( Serializable parentFolderId, RepositoryFile file, IRepositoryFileData data,
+                                      String versionMessage ) {
+      return null;
+    }
+
+    @Override
+    public RepositoryFile createFile( Serializable parentFolderId, RepositoryFile file, IRepositoryFileData data,
+                                      RepositoryFileAcl acl, String versionMessage ) {
+      return null;
+    }
+
+    @Override
+    public RepositoryFile createFolder( Serializable parFolderId, RepositoryFile file, String versionMessage ) {
+      return null;
+    }
+
+    @Override
+    public RepositoryFile createFolder( Serializable parentFolderId, RepositoryFile file, RepositoryFileAcl acl,
+                                        String versionMessage ) {
+      return null;
+    }
+
+    @Override public RepositoryFile updateFolder( RepositoryFile folder, String versionMessage ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFile> getChildren( Serializable folderId ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFile> getChildren( Serializable folderId, String filter ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFile> getChildren( Serializable folderId, String filter, Boolean showHiddenFiles ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFile> getChildren( RepositoryRequest repositoryRequest ) {
+      return null;
+    }
+
+    @Override public RepositoryFile updateFile( RepositoryFile file, IRepositoryFileData data, String versionMessage ) {
+      return null;
+    }
+
+    @Override public void deleteFile( Serializable fileId, boolean permanent, String versionMessage ) {
+
+    }
+
+    @Override public void deleteFile( Serializable fileId, String versionMessage ) {
+
+    }
+
+    @Override public void moveFile( Serializable fileId, String destAbsPath, String versionMessage ) {
+
+    }
+
+    @Override public void copyFile( Serializable fileId, String destAbsPath, String versionMessage ) {
+
+    }
+
+    @Override public void undeleteFile( Serializable fileId, String versionMessage ) {
+
+    }
+
+    @Override public List<RepositoryFile> getDeletedFiles( String origParentFolderPath ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFile> getDeletedFiles( String origParentFolderPath, String filter ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFile> getDeletedFiles() {
+      return null;
+    }
+
+    @Override public boolean canUnlockFile( Serializable fileId ) {
+      return false;
+    }
+
+    @Override public void lockFile( Serializable fileId, String message ) {
+
+    }
+
+    @Override public void unlockFile( Serializable fileId ) {
+
+    }
+
+    @Override public RepositoryFileAcl getAcl( Serializable fileId ) {
+      return null;
+    }
+
+    @Override public RepositoryFileAcl updateAcl( RepositoryFileAcl acl ) {
+      return null;
+    }
+
+    @Override public boolean hasAccess( String path, EnumSet<RepositoryFilePermission> permissions ) {
+      return false;
+    }
+
+    @Override public List<RepositoryFileAce> getEffectiveAces( Serializable fileId ) {
+      return null;
+    }
+
+    @Override public List<RepositoryFileAce> getEffectiveAces( Serializable fileId, boolean forceEntriesInheriting ) {
+      return null;
+    }
+
+    @Override public VersionSummary getVersionSummary( Serializable fileId, Serializable versionId ) {
+      return null;
+    }
+
+    @Override public List<VersionSummary> getVersionSummaryInBatch( List<RepositoryFile> files ) {
+      return null;
+    }
+
+    @Override public List<VersionSummary> getVersionSummaries( Serializable fileId ) {
+      return null;
+    }
+
+    @Override public void deleteFileAtVersion( Serializable fileId, Serializable versionId ) {
+
+    }
+
+    @Override public void restoreFileAtVersion( Serializable fileId, Serializable versionId, String versionMessage ) {
+
+    }
+
+    @Override public List<RepositoryFile> getReferrers( Serializable fileId ) {
+      return null;
+    }
+
+    @Override public void setFileMetadata( Serializable fileId, Map<String, Serializable> metadataMap ) {
+
+    }
+
+    @Override public Map<String, Serializable> getFileMetadata( Serializable fileId ) {
+      return null;
+    }
+
+    @Override public List<Character> getReservedChars() {
+      return null;
+    }
+
+    @Override public List<Locale> getAvailableLocalesForFileById( Serializable fileId ) {
+      return null;
+    }
+
+    @Override public List<Locale> getAvailableLocalesForFileByPath( String relPath ) {
+      return null;
+    }
+
+    @Override public List<Locale> getAvailableLocalesForFile( RepositoryFile repositoryFile ) {
+      return null;
+    }
+
+    @Override public Properties getLocalePropertiesForFileById( Serializable fileId, String locale ) {
+      return null;
+    }
+
+    @Override public Properties getLocalePropertiesForFileByPath( String relPath, String locale ) {
+      return null;
+    }
+
+    @Override public Properties getLocalePropertiesForFile( RepositoryFile repositoryFile, String locale ) {
+      return null;
+    }
+
+    @Override public void setLocalePropertiesForFileById( Serializable fileId, String locale, Properties properties ) {
+
+    }
+
+    @Override public void setLocalePropertiesForFileByPath( String relPath, String locale, Properties properties ) {
+
+    }
+
+    @Override public void setLocalePropertiesForFile( RepositoryFile repoFile, String locale, Properties properties ) {
+
+    }
+
+    @Override public void deleteLocalePropertiesForFile( RepositoryFile repositoryFile, String locale ) {
+
+    }
+  }
+}

--- a/test-src/org/pentaho/reporting/platform/plugin/PluginPerfomanceMonitorContextTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/PluginPerfomanceMonitorContextTest.java
@@ -1,0 +1,93 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.reporting.libraries.base.util.PerformanceLoggingStopWatch;
+import org.pentaho.reporting.platform.plugin.async.ReportListenerThreadHolder;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by dima.prokopenko@gmail.com on 4/26/2016.
+ */
+public class PluginPerfomanceMonitorContextTest {
+
+  private static String TAG = "junit_tag";
+  private static String sessionId = "any_junit_session id";
+  private static String sessionName = "Jhon Doe";
+  private static String requestId = "any_iddqd";
+  private static String perfomanceMetric = "[very slow]";
+
+  private IPentahoSession session = mock( IPentahoSession.class );
+
+  @Before
+  public void before() {
+    when( session.getId() ).thenReturn( sessionId );
+    when( session.getName() ).thenReturn( sessionName );
+
+    PentahoSessionHolder.setSession( session );
+    ReportListenerThreadHolder.setRequestId( requestId );
+  }
+
+  @Test
+  public void createStopWatchNoMessageTest() {
+    PluginPerfomanceMonitorContext context = new PluginPerfomanceMonitorContext();
+    PerformanceLoggingStopWatch sw = context.createStopWatch( TAG );
+    String actual = String.valueOf( sw.getMessage() );
+
+    assertEquals( "null sessionid[any_junit_session id] userid[Jhon Doe] requestid[any_iddqd]", actual );
+  }
+
+  @Test
+  public void createStopWatchMessageTest() {
+    PluginPerfomanceMonitorContext context = new PluginPerfomanceMonitorContext();
+    PerformanceLoggingStopWatch sw = context.createStopWatch( TAG, perfomanceMetric );
+    String actual = String.valueOf( sw.getMessage() );
+
+    assertEquals( "[very slow] sessionid[any_junit_session id] userid[Jhon Doe] requestid[any_iddqd]", actual );
+  }
+
+  /**
+   * Test for null session and null request Id we will not fall into NPE for logging.
+   */
+  @Test
+  public void createStopWatchNoSessionNoIdTest() {
+    PentahoSessionHolder.setSession( null );
+    ReportListenerThreadHolder.setRequestId( null );
+
+    PluginPerfomanceMonitorContext context = new PluginPerfomanceMonitorContext();
+    PerformanceLoggingStopWatch sw = context.createStopWatch( TAG, perfomanceMetric );
+    String actual = String.valueOf( sw.getMessage() );
+
+    assertEquals( "[very slow] sessionid[null] userid[null] requestid[null]", actual );
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    PentahoSessionHolder.removeSession();
+    ReportListenerThreadHolder.clear();
+  }
+}

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionAuditTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionAuditTest.java
@@ -1,0 +1,184 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin.async;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.pentaho.platform.api.engine.ILogger;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.audit.MessageTypes;
+import org.pentaho.reporting.platform.plugin.AuditWrapper;
+import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
+import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
+
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static junit.framework.Assert.assertEquals;
+import static org.mockito.Matchers.anyFloat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by dima.prokopenko@gmail.com on 4/22/2016.
+ */
+public class PentahoAsyncExecutionAuditTest {
+
+  public static final String url = "junit url";
+  public static final String auditId = "auditId";
+  public static final String sessionId = "sessionId";
+  public static final String sessionName = "junitName";
+
+  public static final UUID uuid = UUID.randomUUID();
+
+  SimpleReportingComponent component = mock( SimpleReportingComponent.class );
+  AsyncJobFileStagingHandler handler = mock( AsyncJobFileStagingHandler.class );
+  IPentahoSession session = mock( IPentahoSession.class );
+  AuditWrapper wrapper = mock( AuditWrapper.class );
+
+  @Before
+  public void before() {
+    when( session.getId() ).thenReturn( sessionId );
+    when( session.getName() ).thenReturn( sessionName );
+  }
+
+  @Test
+  public void testSuccessExecutionAudit() throws Exception {
+    PentahoAsyncReportExecution execution =
+      new PentahoAsyncReportExecution( url, component, handler, session, auditId, wrapper );
+    execution.notifyTaskQueued( uuid );
+
+    //this is successful story
+    when( component.execute() ).thenReturn( true );
+
+    execution.call();
+
+    verify( wrapper, Mockito.times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( execution.getClass().getName() ),
+      eq( execution.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_START ),
+      eq( auditId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( null )
+    );
+
+    verify( wrapper, Mockito.times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( execution.getClass().getName() ),
+      eq( execution.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_END ),
+      eq( auditId ),
+      eq( "" ),
+      anyFloat(), // hope more than 0
+      eq( null )
+    );
+  }
+
+  @Test
+  public void testFailedExecutionAudit() throws Exception {
+    PentahoAsyncReportExecution execution =
+      new PentahoAsyncReportExecution( url, component, handler, session, auditId, wrapper );
+    execution.notifyTaskQueued( uuid );
+
+    //this is sad story
+    when( component.execute() ).thenReturn( false );
+
+    execution.call();
+
+    // we always log instance start for every execution attempt
+    verify( wrapper, Mockito.times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( execution.getClass().getName() ),
+      eq( execution.getClass().getName() ),
+      eq( MessageTypes.INSTANCE_START ),
+      eq( auditId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( null )
+    );
+
+    // no async reports for this case.
+    verify( wrapper, Mockito.times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( execution.getClass().getName() ),
+      eq( execution.getClass().getName() ),
+      eq( MessageTypes.FAILED ),
+      eq( auditId ),
+      eq( "" ),
+      eq( (float) 0 ),
+      eq( null )
+    );
+  }
+
+  /**
+   * We need a special wrapper that will be able to get id from one thread (created for report execution)
+   * and made this value accessible in contest of this junit test thread.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testInstanceIdIsSet() throws Exception {
+
+    final CountDownLatch latch = new CountDownLatch(1);
+    ThreadSpyAuditWrapper wrapper = new ThreadSpyAuditWrapper( latch );
+
+    String expected = UUID.randomUUID().toString();
+
+    PentahoAsyncReportExecution execution =
+      new PentahoAsyncReportExecution( url, component, handler, session, expected, wrapper );
+
+    PentahoAsyncExecutor executor = new PentahoAsyncExecutor( 2 );
+    executor.addTask( execution, session );
+
+    // hope 10 sec is enough
+    latch.await( 10, TimeUnit.SECONDS );
+
+    assertEquals( expected, wrapper.capturedId );
+  }
+
+  private static class ThreadSpyAuditWrapper extends AuditWrapper {
+
+    String capturedId;
+    private CountDownLatch latch;
+
+    ThreadSpyAuditWrapper ( CountDownLatch latch ) {
+      this.latch = latch;
+    }
+
+    @Override
+    public void audit( String instanceId, final String userId, String actionName, final String objectType,
+                       String processId, final String messageType, final String message, final String value, final float duration,
+                       final ILogger logger ) {
+      latch.countDown();
+      capturedId = ReportListenerThreadHolder.getRequestId();
+    }
+  }
+}

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionInterruptTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionInterruptTest.java
@@ -27,6 +27,7 @@ import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.core.system.boot.PlatformInitializationException;
+import org.pentaho.reporting.platform.plugin.AuditWrapper;
 import org.pentaho.reporting.platform.plugin.MicroPlatformFactory;
 import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
@@ -80,7 +81,7 @@ public class PentahoAsyncExecutionInterruptTest {
         handler =
         new AsyncJobFileStagingHandler( session );
     PentahoAsyncReportExecution
-        task = new PentahoAsyncReportExecution( "junit", reportComponent, handler, session, null );
+        task = new PentahoAsyncReportExecution( "junit", reportComponent, handler, session, null, AuditWrapper.NULL );
 
     UUID id = executor.addTask( task, session );
 

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionTest.java
@@ -29,6 +29,7 @@ import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.libraries.base.config.ModifiableConfiguration;
+import org.pentaho.reporting.platform.plugin.AuditWrapper;
 import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
 import org.pentaho.reporting.platform.plugin.staging.IFixedSizeStreamingContent;
@@ -103,7 +104,7 @@ public class PentahoAsyncExecutionTest {
   }
 
   private PentahoAsyncReportExecution createMockCallable() {
-    return new PentahoAsyncReportExecution( "junit-path", component, handler, userSession, null ) {
+    return new PentahoAsyncReportExecution( "junit-path", component, handler, userSession, null, AuditWrapper.NULL ) {
       @Override
       protected AsyncReportStatusListener createListener( UUID id ) {
         return new AsyncReportStatusListener( "display_path", id, "text/html" );
@@ -191,7 +192,7 @@ public class PentahoAsyncExecutionTest {
 
   private PentahoAsyncReportExecution getSleepingSpy( final AtomicBoolean run, IPentahoSession session ) {
     PentahoAsyncReportExecution exec =
-      new PentahoAsyncReportExecution( "junit-path", component, handler, session, "junit" ) {
+      new PentahoAsyncReportExecution( "junit-path", component, handler, session, "junit", AuditWrapper.NULL ) {
         @Override
         public IFixedSizeStreamingContent call() throws Exception {
           while ( !run.get() && !Thread.currentThread().isInterrupted() ) {

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
@@ -32,6 +32,7 @@ import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.libraries.base.config.ModifiableConfiguration;
+import org.pentaho.reporting.platform.plugin.AuditWrapper;
 import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
 import org.pentaho.reporting.platform.plugin.staging.IFixedSizeStreamingContent;
@@ -157,7 +158,7 @@ public class PentahoAsyncReportExecutorTest {
   }
 
   private PentahoAsyncReportExecution createMockCallable( IPentahoSession session ) {
-    return new PentahoAsyncReportExecution( "junit-path", component, handler, session, null ) {
+    return new PentahoAsyncReportExecution( "junit-path", component, handler, session, null, AuditWrapper.NULL ) {
       @Override
       protected AsyncReportStatusListener createListener( final UUID id ) {
         final AsyncReportState state = new AsyncReportState( id, getReportPath() );
@@ -250,7 +251,7 @@ public class PentahoAsyncReportExecutorTest {
 
     // must have two separate instances, as callable holds unique ID and listener for each addTask(..)
     final UUID id1 = exec.addTask(  new PentahoAsyncReportExecution( "junit-path",
-            component, handler, PentahoSessionHolder.getSession(), null ) {
+            component, handler, PentahoSessionHolder.getSession(), null, AuditWrapper.NULL ) {
       @Override
       protected AsyncReportStatusListener createListener(final UUID id) {
         return testListener;


### PR DESCRIPTION
1) Introduce PluginPerfomanceMonitorContext that will provide session info
for reporting perfomance logging.
We will track perfomance metrics with logging table records with
instanceId from tomcat controller and 'message' field in audit log.

2) Re-check audit logging, remove static hard-coded invocation to be able
to mock in junits.

See original jira case for details.