### PR TITLE
[BACKLOG-7898] - log cancelled status for audit table

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/async/AbstractAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AbstractAsyncReportExecution.java
@@ -105,11 +105,13 @@ public abstract class AbstractAsyncReportExecution<TReportState extends IAsyncRe
 
   protected void fail() {
     // do not erase canceled status
+    String messageType = MessageTypes.CANCELLED;
     if ( listener != null && !listener.getState().getStatus().equals( AsyncExecutionStatus.CANCELED ) ) {
       listener.setStatus( AsyncExecutionStatus.FAILED );
+      messageType = MessageTypes.FAILED;
     }
     audit.audit( safeSession.getId(), safeSession.getName(), url, getClass().getName(), getClass().getName(),
-      MessageTypes.FAILED, auditId, "", 0, null );
+      messageType, auditId, "", 0, null );
   }
 
   protected AsyncReportStatusListener createListener( final UUID instanceId, final List<? extends ReportProgressListener> callbackListeners ) {

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
@@ -98,8 +98,7 @@ public class PentahoAsyncReportExecution extends AbstractAsyncReportExecution<IA
       // uncompilable jar versions.
       // We have to avoid to hang on working status.
       log.error( "fail to execute report in async mode: " + ee );
-      // to be sure after an error output stream is closed
-      IOUtils.closeQuietly( handler.getStagingOutputStream() );
+
       if ( ee.getMessage() != null ) {
         listener.setErrorMessage( ee.getMessage() );
       }

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionAuditTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutionAuditTest.java
@@ -18,39 +18,50 @@
 
 package org.pentaho.reporting.platform.plugin.async;
 
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 import org.pentaho.platform.api.engine.ILogger;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.engine.core.audit.MessageTypes;
-import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
 import org.pentaho.reporting.platform.plugin.AuditWrapper;
 import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.staging.AsyncJobFileStagingHandler;
+import org.pentaho.reporting.platform.plugin.staging.IFixedSizeStreamingContent;
 
+import java.io.OutputStream;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Stack;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.anyFloat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 public class PentahoAsyncExecutionAuditTest {
 
-  public static final String url = "junit url";
+  private static final String url = "junit url";
   private static final String auditId = "auditId";
-  public static final String sessionId = "sessionId";
+  private static final String sessionId = "sessionId";
   private static final String sessionName = "junitName";
 
-  public static final UUID uuid = UUID.randomUUID();
+  private static final UUID uuid = UUID.randomUUID();
 
   private SimpleReportingComponent component = mock( SimpleReportingComponent.class );
   private AsyncJobFileStagingHandler handler = mock( AsyncJobFileStagingHandler.class );
-  IPentahoSession session = mock( IPentahoSession.class );
+  private IPentahoSession session = mock( IPentahoSession.class );
   private AuditWrapper wrapper = mock( AuditWrapper.class );
+
+  private OutputStream outputStream = mock( OutputStream.class );
 
   @Before
   public void before() {
@@ -62,7 +73,7 @@ public class PentahoAsyncExecutionAuditTest {
   public void testSuccessExecutionAudit() throws Exception {
     final PentahoAsyncReportExecution execution =
       new PentahoAsyncReportExecution( url, component, handler, session, auditId, wrapper );
-    execution.notifyTaskQueued( uuid, Collections.<ReportProgressListener>emptyList() );
+    execution.notifyTaskQueued( uuid, Collections.emptyList() );
 
     //this is successful story
     when( component.execute() ).thenReturn( true );
@@ -100,7 +111,7 @@ public class PentahoAsyncExecutionAuditTest {
   public void testFailedExecutionAudit() throws Exception {
     final PentahoAsyncReportExecution execution =
       new PentahoAsyncReportExecution( url, component, handler, session, auditId, wrapper );
-    execution.notifyTaskQueued( uuid, Collections.<ReportProgressListener>emptyList() );
+    execution.notifyTaskQueued( uuid, Collections.emptyList() );
 
     //this is sad story
     when( component.execute() ).thenReturn( false );
@@ -154,14 +165,265 @@ public class PentahoAsyncExecutionAuditTest {
     final PentahoAsyncReportExecution execution =
       new PentahoAsyncReportExecution( url, component, handler, session, expected, wrapper );
 
-    final PentahoAsyncExecutor executor = new PentahoAsyncExecutor( 2 );
+    final PentahoAsyncExecutor<IAsyncReportState> executor = new PentahoAsyncExecutor<>( 2, 0 );
     executor.addTask( execution, session );
 
     latch.await();
-    synchronized ( latch ) {
+
+    synchronized( latch ) {
       assertEquals( expected, wrapper.capturedId );
     }
   }
+
+  /**
+   * This is quite intricate test, but make attempt to inspect thread pool executor as much detailed as possible.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testCancellationStatusTest() throws Exception {
+
+    final int CAPACITY = 4;
+    final int NUMBER_OF_THREADS = CAPACITY + 1;
+
+    // controlled execution:
+    final CountDownLatch startLatch = new CountDownLatch( 1 );
+    final CountDownLatch waitSubmitted = new CountDownLatch( CAPACITY );
+    final CountDownLatch finalBlock = new CountDownLatch( CAPACITY );
+
+    // this is one more hack - we waiting on a handler's method that will be called in finally block
+    // this way synchronizing on catch() block was executed.
+    final Answer<OutputStream> handlerAnswer = invocation -> {
+      finalBlock.countDown();
+      return outputStream;
+    };
+    when( handler.getStagingOutputStream() ).thenAnswer( handlerAnswer );
+
+    // hello java 8!
+    final Answer answer = invocation -> {
+      waitSubmitted.countDown();
+      startLatch.await( 10, TimeUnit.SECONDS );
+      return true;
+    };
+
+    final Stack<UUID> tasksIds = new Stack<>();
+    final PentahoAsyncExecutor<IAsyncReportState> executor = new PentahoAsyncExecutor<>( CAPACITY, 0 );
+
+    // add one more excessive execution
+    UUID id;
+    for ( int i = 0; i < NUMBER_OF_THREADS; i++ ) {
+      final SimpleReportingComponent component = mock( SimpleReportingComponent.class );
+      // every time component.execute() called - we do await on answer object
+      // we wait on a latch exactly number of submitted threads
+      when( component.execute() ).thenAnswer( answer );
+
+      final PentahoAsyncReportExecution execution =
+        new PentahoAsyncReportExecution( url, component, handler, session, auditId, wrapper );
+      id = executor.addTask( execution, session );
+
+      // we save id's in order they would submitted
+      assertNotNull( id );
+      tasksIds.push( id );
+    }
+
+    // wait for all working tasks will hang on monitor 'startLatch'
+    // at least we have to have 4 tasks waited for a startLatch
+    waitSubmitted.await( 10, TimeUnit.SECONDS );
+
+    final IAsyncReportState state5 = executor.getReportState( tasksIds.peek(), session );
+    assertEquals( "4 running, one waiting", AsyncExecutionStatus.QUEUED, state5.getStatus() );
+
+    // now collect all futures to a one place
+    List<ListenableFuture<IFixedSizeStreamingContent>> futures = new ArrayList<>();
+    final List<IAsyncReportState> states = new ArrayList<>();
+    do {
+      // this is a cheat: we know this futures really ListenableFuture.
+      // if you have class cast here... will require additional code to
+      // wait fot their completition, see code below...
+      futures.add( (ListenableFuture<IFixedSizeStreamingContent>) executor.getFuture( tasksIds.peek(), session ) );
+      states.add( executor.getReportState( tasksIds.pop(), session ));
+    } while ( !tasksIds.isEmpty() );
+
+    assertEquals( "we have 5: 4 running and one waiting future", NUMBER_OF_THREADS, futures.size() );
+
+    // we manually explore futures statuses
+    int done = 0;
+    int cancelled = 0;
+    // we have 5 running and no cancelled (one running is queued)
+    for ( final ListenableFuture<IFixedSizeStreamingContent> item : futures ) {
+      if ( item.isCancelled() ) {
+        cancelled++;
+      } else if ( item.isDone() ) {
+        done++;
+      }
+    }
+    assertEquals( "none done since all waiting on a latch", 0, done );
+    assertEquals( "still none cancelled", 0, cancelled );
+
+    // simulate on-logout call - will attempt to cancel all tasks.
+    executor.onLogout( session );
+
+    // again - do a detailed insepction
+    done = 0;
+    cancelled = 0;
+    // we have 5 running and no cancelled (one running is queued)
+    for ( final ListenableFuture<IFixedSizeStreamingContent> item : futures ) {
+      if ( item.isCancelled() ) {
+        cancelled++;
+      } else if ( item.isDone() ) {
+        done++;
+      }
+    }
+    assertEquals( "none done", 0, done );
+    assertEquals( "cancelled all", NUMBER_OF_THREADS, cancelled );
+
+    // after all futures seems to be cancelled - let try to complete them.
+    final ListenableFuture<List<IFixedSizeStreamingContent>> all = Futures.successfulAsList( futures );
+    // now - release all - if someone was not cancelled - it make attempt to execute successfully.
+    startLatch.countDown();
+    // wait for if any is still pending
+    all.get();
+
+    // wait here before ALL threads come into final block
+    finalBlock.await( 10, TimeUnit.SECONDS );
+
+    verify( wrapper, atLeast( CAPACITY ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( PentahoAsyncReportExecution.class.getName() ),
+      eq( PentahoAsyncReportExecution.class.getName() ),
+      eq( MessageTypes.CANCELLED ),
+      eq( auditId ),
+      eq( "" ),
+      anyFloat(),
+      any( ILogger.class )
+    );
+  }
+
+  /**
+   * This is almost a copy of #testCancellationStatusTest above, but now we have one 'scheduled' execution.
+   *
+   */
+  @Test
+  public void testScheduledExecutionsNotGetCancelled() throws Exception {
+    // we still have 4 threads capacity
+    final int CAPACITY = 4;
+    // but now one of the threads is scheduled
+    final int NUMBER_OF_THREADS = CAPACITY + 2;
+
+    // controlled execution:
+    final CountDownLatch startLatch = new CountDownLatch( 1 );
+    final CountDownLatch waitSubmitted = new CountDownLatch( CAPACITY );
+    final CountDownLatch finalBlock = new CountDownLatch( NUMBER_OF_THREADS - 1 );
+
+    final Answer<OutputStream> handlerAnswer = invocation -> {
+      finalBlock.countDown();
+      return outputStream;
+    };
+    when( handler.getStagingOutputStream() ).thenAnswer( handlerAnswer );
+
+    // hello java 8!
+    final Answer answer = invocation -> {
+      waitSubmitted.countDown();
+      startLatch.await( 10, TimeUnit.SECONDS );
+      return true;
+    };
+
+    final Stack<UUID> tasksIds = new Stack<>();
+    final PentahoAsyncExecutor<IAsyncReportState> executor = new PentahoAsyncExecutor<>( CAPACITY, 0 );
+
+    UUID id;
+    for ( int i = 0; i < NUMBER_OF_THREADS; i++ ) {
+      final SimpleReportingComponent component = mock( SimpleReportingComponent.class );
+      when( component.execute() ).thenAnswer( answer );
+      final PentahoAsyncReportExecution execution =
+        new PentahoAsyncReportExecution( url, component, handler, session, auditId, wrapper );
+      id = executor.addTask( execution, session );
+      assertNotNull( id );
+      tasksIds.push( id );
+    }
+    waitSubmitted.await( 10, TimeUnit.SECONDS );
+
+    // remember - retrieve but does not remove
+    final IAsyncReportState state5 = executor.getReportState( tasksIds.peek(), session );
+    assertEquals( "4 running, one waiting", AsyncExecutionStatus.QUEUED, state5.getStatus() );
+
+    // what we doing now - is attempt to schedule a peek of queue.
+    // this is creates 'queued + scheduled' execution
+    executor.schedule( tasksIds.peek(), session );
+
+    final List<ListenableFuture<IFixedSizeStreamingContent>> futures = new ArrayList<>();
+    do {
+      futures.add( (ListenableFuture<IFixedSizeStreamingContent>) executor.getFuture( tasksIds.pop(), session ) );
+    } while ( !tasksIds.isEmpty() );
+
+    assertEquals( "we have running and waiting futures", NUMBER_OF_THREADS, futures.size() );
+
+    int done = 0;
+    int cancelled = 0;
+    for ( final ListenableFuture<IFixedSizeStreamingContent> item : futures ) {
+      if ( item.isCancelled() ) {
+        cancelled++;
+      } else if ( item.isDone() ) {
+        done++;
+      }
+    }
+    assertEquals( "none done since all waiting on a latch", 0, done );
+    assertEquals( "still none cancelled", 0, cancelled );
+
+    // simulate on-logout call - will attempt to cancel all tasks.
+    // remember - now we have one scheduled execution - so it should survive onLogout call
+    executor.onLogout( session );
+
+    final ListenableFuture<List<IFixedSizeStreamingContent>> all = Futures.successfulAsList( futures );
+    startLatch.countDown();
+    all.get();
+
+    // again - do a detailed inspection
+    done = 0;
+    cancelled = 0;
+    // we have 5 running and no cancelled (one running is queued)
+    for ( final ListenableFuture<IFixedSizeStreamingContent> item : futures ) {
+      if ( item.isCancelled() ) {
+        cancelled++;
+      } else if ( item.isDone() ) {
+        done++;
+      }
+    }
+    assertEquals( "scheduled is done:", 1, done );
+    assertEquals( "have cancelled all, BUT SCHEDULED!", NUMBER_OF_THREADS - 1 , cancelled );
+
+    finalBlock.await( 10, TimeUnit.SECONDS );
+
+    verify( wrapper, atLeast( CAPACITY ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( PentahoAsyncReportExecution.class.getName() ),
+      eq( PentahoAsyncReportExecution.class.getName() ),
+      eq( MessageTypes.CANCELLED ),
+      eq( auditId ),
+      eq( "" ),
+      anyFloat(),
+      any( ILogger.class )
+    );
+
+    // this is ONE sucesfull execution fot scheduled task since it was not cancelled!!!
+    verify( wrapper, Mockito.times( 1 ) ).audit(
+      eq( sessionId ),
+      eq( sessionName ),
+      eq( url ),
+      eq( PentahoAsyncReportExecution.class.getName() ),
+      eq( PentahoAsyncReportExecution.class.getName() ),
+      eq( MessageTypes.INSTANCE_END ),
+      eq( auditId ),
+      eq( "" ),
+      anyFloat(),
+      any( ILogger.class )
+    );
+  }
+
 
   private static class ThreadSpyAuditWrapper extends AuditWrapper {
 
@@ -173,7 +435,7 @@ public class PentahoAsyncExecutionAuditTest {
     }
 
     @Override
-    public void audit( final String instanceId, final String userId, final String actionName, final String objectType,
+    public void audit( final String instanceId, final String userId, String actionName, final String objectType,
                        final String processId, final String messageType, final String message, final String value,
                        final float duration,
                        final ILogger logger ) {


### PR DESCRIPTION
- Add cancelled status for cancelled executions
- Fix excessive handler 'handler.getStagingOutputStream()' : we don't need to close it in catch block since we do close it in finally block
- Added tests for execution cancellations in thread pool as detailed as possible.