### PR TITLE
[CLEANUP] - Cleanup cache files when platform stops

### DIFF
--- a/package-res/reportviewer/dojo/pentaho/reportviewer/FeedbackScreen.html
+++ b/package-res/reportviewer/dojo/pentaho/reportviewer/FeedbackScreen.html
@@ -1,9 +1,9 @@
 <table class="feedbackscreen-content" onkeyup="">
     <tr>
-        <td>
+        <td class="feedbackscreencontentbody">
             <table class="upper-table">
                 <tr>
-                    <td data-dojo-attach-point="feedbacktitle" class="feedbackscreentitle">
+                    <td data-dojo-attach-point="feedbacktitle" class="feedbackscreentitle Caption">
                     </td>
                 </tr>
                 <tr>
@@ -11,7 +11,7 @@
                     </td>
                 </tr>
                 <tr>
-                    <td>
+                    <td class="feedbackscreentextmiddle">
                         <div data-dojo-type="dijit.ProgressBar"
                             data-dojo-id="progressBar" id="downloadProgress" data-dojo-props="maximum:100"></div>
                     </td>

--- a/package-res/reportviewer/reportviewer.css
+++ b/package-res/reportviewer/reportviewer.css
@@ -364,24 +364,13 @@ div.prompt-panel {
 .feedbackscreen-content {
   /* fallback color */
   background: #f5f6f8;
-  padding-left: 7px;
-  padding-top: 7px;
-  padding-right: 7px;
   width: 100%;
-}
-
-.feedbackscreentitle {
-  padding-top: 0px;
-  color: #1973bc;
-  font-family: opensanslight, Helvetica, Arial, Sans serif;
-  font-size: 18px;
-  vertical-align: top;
-  heightx: 60px;
+  border-spacing: 0px;
 }
 
 .feedbackscreentextupper {
   color: #26363d;
-  padding: 10px 0 20px 0;
+  padding: 10px 0 20px 7px;
   vertical-align: top;
   line-height: 2em;
 }
@@ -396,6 +385,11 @@ div.prompt-panel {
 
 .upper-table {  
   width: 100%;
+  border-spacing: 0;
+}
+
+.feedbackscreencontentbody  {  
+  padding: 0 0 0 0;
 }
 
 .bottom-table {  
@@ -405,10 +399,6 @@ div.prompt-panel {
 
 #downloadProgress {
   width:98%;
-}
-
-.dijitDialog .dijitDialogPaneContent #downloadProgress .dijitProgressBarTile {
-  background: #dce7ed;
 }
 
 .pentaho-notification {

--- a/package-res/reportviewer/themes/crystal/Crystal.css
+++ b/package-res/reportviewer/themes/crystal/Crystal.css
@@ -1,0 +1,11 @@
+.dijitDialog .dijitDialogPaneContent #downloadProgress .dijitProgressBarTile {
+  background: #dce7ed; 
+}
+
+.feedbackscreentextmiddle {
+  padding: 0 0 0 7px;
+}
+
+.feedbackscreentitle {
+  padding-left: 7px !important;
+}

--- a/package-res/reportviewer/themes/onyx/Onyx.css
+++ b/package-res/reportviewer/themes/onyx/Onyx.css
@@ -1,0 +1,24 @@
+.dijitDialog .dijitDialogPaneContent #downloadProgress .dijitProgressBarTile {
+  background: #cbefa3;
+}
+
+.feedbackscreentextupper {  
+  padding: 10px 0 20px 6px;
+  line-height: 2em;
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+}
+
+.feedbackscreentextmiddle {
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+  padding: 0 0 0 6px;
+}
+
+.bottom-table {  
+  width: 100%;
+  padding-bottom: 9px;
+  border-left: 1px solid black;
+  border-right: 1px solid black;
+  border-bottom: 1px solid black;
+}

--- a/src/org/pentaho/reporting/platform/plugin/async/AsyncSystemListener.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AsyncSystemListener.java
@@ -22,18 +22,24 @@ package org.pentaho.reporting.platform.plugin.async;
 import org.pentaho.platform.api.engine.IPentahoSession;
 import org.pentaho.platform.api.engine.IPentahoSystemListener;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.reporting.platform.plugin.cache.IReportContentCache;
 
 public class AsyncSystemListener implements IPentahoSystemListener {
   private IPentahoAsyncExecutor asyncExecutor;
+  private IReportContentCache cache;
 
   @Override public boolean startup( final IPentahoSession iPentahoSession ) {
     asyncExecutor = PentahoSystem.get( IPentahoAsyncExecutor.class );
+    cache = PentahoSystem.get( IReportContentCache.class );
     return true;
   }
 
   @Override public void shutdown() {
     if ( null != asyncExecutor ) {
       asyncExecutor.shutdown();
+    }
+    if ( null != cache ) {
+      cache.cleanup();
     }
   }
 }

--- a/src/org/pentaho/reporting/platform/plugin/async/AutoScheduleListener.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/AutoScheduleListener.java
@@ -1,0 +1,63 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin.async;
+
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.reporting.engine.classic.core.event.ReportProgressEvent;
+import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
+
+import java.util.UUID;
+
+class AutoScheduleListener implements ReportProgressListener {
+
+  private boolean scheduled = false;
+  private int threshold;
+  private UUID id;
+  private IPentahoSession session;
+  private IPentahoAsyncExecutor pentahoAsyncExecutor;
+
+  protected AutoScheduleListener( final UUID id, final IPentahoSession session, final int threshold,
+                                  final IPentahoAsyncExecutor pentahoAsyncExecutor ) {
+    this.id = id;
+    this.threshold = threshold;
+    this.session = session;
+
+    this.pentahoAsyncExecutor = pentahoAsyncExecutor;
+  }
+
+  private synchronized void autoSchedule( final ReportProgressEvent reportProgressEvent ) {
+    if ( !scheduled && threshold > 0 && reportProgressEvent != null
+      && reportProgressEvent.getMaximumRow() > threshold ) {
+      pentahoAsyncExecutor.schedule( id, session );
+      scheduled = true;
+    }
+  }
+
+  @Override public void reportProcessingStarted( final ReportProgressEvent reportProgressEvent ) {
+    autoSchedule( reportProgressEvent );
+  }
+
+  @Override public void reportProcessingUpdate( final ReportProgressEvent reportProgressEvent ) {
+    autoSchedule( reportProgressEvent );
+  }
+
+  @Override public void reportProcessingFinished( final ReportProgressEvent reportProgressEvent ) {
+
+  }
+}

--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
@@ -35,8 +35,6 @@ import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.platform.engine.security.SecurityHelper;
 import org.pentaho.platform.util.StringUtil;
 import org.pentaho.platform.util.web.MimeHelper;
-import org.pentaho.reporting.engine.classic.core.event.ReportProgressEvent;
-import org.pentaho.reporting.engine.classic.core.event.ReportProgressListener;
 import org.pentaho.reporting.libraries.base.util.ArgumentNullException;
 import org.pentaho.reporting.libraries.repository.ContentLocation;
 import org.pentaho.reporting.platform.plugin.repository.ReportContentRepository;
@@ -65,7 +63,8 @@ public class PentahoAsyncExecutor<TReportState extends IAsyncReportState>
   public static final String BEAN_NAME = "IPentahoAsyncExecutor";
 
   private static final Log log = LogFactory.getLog( PentahoAsyncExecutor.class );
-  private static final String UNABLE_DELETE_TEMP_FILES_ON_SESSION_LOGOUT = "Unable delete temp files on session logout.";
+  private static final String UNABLE_DELETE_TEMP_FILES_ON_SESSION_LOGOUT =
+    "Unable delete temp files on session logout.";
 
   private Map<CompositeKey, ListenableFuture<IFixedSizeStreamingContent>> futures = new ConcurrentHashMap<>();
   private Map<CompositeKey, IAsyncReportExecution<TReportState>> tasks = new ConcurrentHashMap<>();
@@ -131,7 +130,7 @@ public class PentahoAsyncExecutor<TReportState extends IAsyncReportState>
     final CompositeKey key = new CompositeKey( session, id );
 
     task.notifyTaskQueued( id,
-      Collections.singletonList( new AutoScheduleListener( id, session, autoSchedulerThreshold ) ) );
+      Collections.singletonList( new AutoScheduleListener( id, session, autoSchedulerThreshold, this ) ) );
 
     log.debug( "register async execution for task: " + task.toString() );
 
@@ -376,36 +375,5 @@ public class PentahoAsyncExecutor<TReportState extends IAsyncReportState>
 
   }
 
-  private class AutoScheduleListener implements ReportProgressListener {
 
-    private boolean scheduled = false;
-    private int threshold;
-    private UUID id;
-    private IPentahoSession session;
-
-    AutoScheduleListener( final UUID id, final IPentahoSession session, final int threshold ) {
-      this.id = id;
-      this.threshold = threshold;
-      this.session = session;
-    }
-
-    private synchronized void autoSchedule( final ReportProgressEvent reportProgressEvent ) {
-      if ( !scheduled && threshold > 0 && reportProgressEvent != null && reportProgressEvent.getMaximumRow() > threshold ) {
-        schedule( id, session );
-        scheduled = true;
-      }
-    }
-
-    @Override public void reportProcessingStarted( final ReportProgressEvent reportProgressEvent ) {
-      autoSchedule( reportProgressEvent );
-    }
-
-    @Override public void reportProcessingUpdate( final ReportProgressEvent reportProgressEvent ) {
-      autoSchedule( reportProgressEvent );
-    }
-
-    @Override public void reportProcessingFinished( final ReportProgressEvent reportProgressEvent ) {
-
-    }
-  }
 }

--- a/src/org/pentaho/reporting/platform/plugin/cache/DeleteOldOnAccessCache.java
+++ b/src/org/pentaho/reporting/platform/plugin/cache/DeleteOldOnAccessCache.java
@@ -93,6 +93,13 @@ public class DeleteOldOnAccessCache extends AbstractReportContentCache {
     return super.get( key );
   }
 
+  /**
+   * Cleans old files
+   */
+  @Override public void cleanup() {
+    cleanUp();
+  }
+
   private void cleanUp() {
     logger.debug( "Starting periodical cache eviction" );
     final long currentTimeMillis = System.currentTimeMillis();

--- a/src/org/pentaho/reporting/platform/plugin/cache/IReportContentCache.java
+++ b/src/org/pentaho/reporting/platform/plugin/cache/IReportContentCache.java
@@ -21,4 +21,6 @@ public interface IReportContentCache {
   boolean put( String key, IReportContent value );
 
   IReportContent get( String key );
+
+  void cleanup();
 }

--- a/src/org/pentaho/reporting/platform/plugin/cache/PluginSessionCache.java
+++ b/src/org/pentaho/reporting/platform/plugin/cache/PluginSessionCache.java
@@ -57,6 +57,13 @@ public class PluginSessionCache extends AbstractReportContentCache {
   }
 
   /**
+   * Cleans all session files
+   */
+  @Override public void cleanup() {
+    getBackend().purge( Collections.singletonList( SEGMENT ) );
+  }
+
+  /**
    * Logout listener that purges cache
    */
   private class LogoutHandler implements ILogoutListener {

--- a/src/org/pentaho/reporting/platform/plugin/output/CachingPageableHTMLOutput.java
+++ b/src/org/pentaho/reporting/platform/plugin/output/CachingPageableHTMLOutput.java
@@ -211,7 +211,7 @@ public class CachingPageableHTMLOutput extends PageableHTMLOutput {
     }
   }
 
-  private IReportContent regenerateCache( final MasterReport report, final int yieldRate, final String key,
+  IReportContent regenerateCache( final MasterReport report, final int yieldRate, final String key,
                                           final int acceptedPage )
     throws ReportProcessingException {
     logger.warn( "Regenerating report data for " + key );

--- a/test-src/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListenerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/AsyncReportStatusListenerTest.java
@@ -32,6 +32,13 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public class AsyncReportStatusListenerTest {
+
+  public static final String STUB =
+    "AsyncReportStatusListener{path='', uuid=370c1ff4-06de-4b32-b966-f7bd8c2da7b2, status=QUEUED, progress=0, page=0,"
+      + " totalPages=0, generatedPage=0, activity='null', row=0, firstPageMode=true, mimeType='', "
+      + "errorMessage='370c1ff4-06de-4b32-b966-f7bd8c2da7b2'}";
+  public static final String STUV_UUID = "370c1ff4-06de-4b32-b966-f7bd8c2da7b2";
+
   @Test
   public void isFirstPageMode() throws Exception {
     final ModifiableConfiguration edConf = ClassicEngineBoot.getInstance().getEditableConfig();
@@ -117,7 +124,32 @@ public class AsyncReportStatusListenerTest {
         new ReportProgressEvent( this, entry.getKey(), 0, 0, 0, 0, 0, 0 ) );
       assertEquals( entry.getValue(), listener.getState().getActivity() );
     }
+  }
 
+  @Test
+  public void testTostring() {
+    final ModifiableConfiguration edConf = ClassicEngineBoot.getInstance().getEditableConfig();
+    edConf.setConfigProperty( "org.pentaho.reporting.platform.plugin.output.FirstPageMode", "true" );
+    final AsyncReportStatusListener listener =
+      new AsyncReportStatusListener( "", UUID.fromString( STUV_UUID ), "",
+        Collections.<ReportProgressListener>emptyList() );
+    listener.setErrorMessage( STUV_UUID );
+    assertEquals( STUB, listener.toString() );
+    edConf.setConfigProperty( "org.pentaho.reporting.platform.plugin.output.FirstPageMode", "false" );
+  }
 
+  @Test
+  public void testCallbacks() {
+    final ReportProgressListener mock = mock( ReportProgressListener.class );
+    final AsyncReportStatusListener listener =
+      new AsyncReportStatusListener( "", UUID.fromString( STUV_UUID ), "",
+        Collections.singletonList( mock ) );
+    final ReportProgressEvent event = mock( ReportProgressEvent.class );
+    listener.reportProcessingStarted( event );
+    listener.reportProcessingUpdate( event );
+    listener.reportProcessingFinished( event );
+    verify( mock, times( 1 ) ).reportProcessingStarted( event );
+    verify( mock, times( 1 ) ).reportProcessingUpdate( event );
+    verify( mock, times( 1 ) ).reportProcessingFinished( event );
   }
 }

--- a/test-src/org/pentaho/reporting/platform/plugin/async/AsyncSystemListenerIT.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/AsyncSystemListenerIT.java
@@ -1,0 +1,105 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin.async;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
+import org.pentaho.platform.engine.core.system.StandaloneSession;
+import org.pentaho.reporting.platform.plugin.MicroPlatformFactory;
+import org.pentaho.reporting.platform.plugin.cache.DeleteOldOnAccessCache;
+import org.pentaho.reporting.platform.plugin.cache.FileSystemCacheBackend;
+import org.pentaho.reporting.platform.plugin.cache.IReportContent;
+import org.pentaho.reporting.platform.plugin.cache.IReportContentCache;
+import org.pentaho.reporting.platform.plugin.cache.PluginSessionCache;
+import org.pentaho.reporting.platform.plugin.cache.ReportContentImpl;
+import org.pentaho.test.platform.engine.core.MicroPlatform;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith( Parameterized.class )
+public class AsyncSystemListenerIT {
+
+  private static final IReportContent SOME_VALUE =
+    new ReportContentImpl( 100, (Map<Integer, byte[]>) Collections.singletonMap( 1, new byte[] { 1, 3, 4, 5 } ) );
+
+  private static final FileSystemCacheBackend cacheBackend = new FileSystemCacheBackend();
+
+
+  public AsyncSystemListenerIT( final IReportContentCache cache,
+                                final boolean isNull ) {
+    this.cache = cache;
+    this.isNull = isNull;
+  }
+
+  private IReportContentCache cache;
+  private boolean isNull;
+
+
+  @Parameterized.Parameters
+  public static Collection primeNumbers() {
+    final DeleteOldOnAccessCache deleteOldOnAccessCache = new DeleteOldOnAccessCache( cacheBackend );
+    deleteOldOnAccessCache.setDaysToLive( 1 );
+    return Arrays.asList( new Object[][] {
+      { new PluginSessionCache( cacheBackend ), true },
+      { deleteOldOnAccessCache, false }
+    } );
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    assertTrue( cacheBackend.purge( Collections.singletonList( "." ) ) );
+  }
+
+
+  /**
+   * Session cache should purge all session files Delete old on access should not delete files
+   *
+   * @throws Exception
+   */
+  @Test
+  public void lifecycle() throws Exception {
+    final MicroPlatform microPlatform = MicroPlatformFactory.create();
+    microPlatform.define( "IPentahoAsyncExecutor", new PentahoAsyncExecutor( 10, 0 ) );
+
+
+    microPlatform.define( "IReportContentCache",
+      cache );
+    final AsyncSystemListener asyncSystemListener = spy( new AsyncSystemListener() );
+    microPlatform.addLifecycleListener( asyncSystemListener );
+    microPlatform.start();
+    PentahoSessionHolder.setSession( new StandaloneSession( "test" ) );
+    verify( asyncSystemListener, times( 1 ) ).startup( any( IPentahoSession.class ) );
+    cache.put( "test", SOME_VALUE );
+    assertNotNull( cache.get( "test" ) );
+    microPlatform.stop();
+
+    assertEquals( cache.get( "test" ) == null, isNull );
+  }
+
+
+}

--- a/test-src/org/pentaho/reporting/platform/plugin/async/AsyncSystemListenerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/AsyncSystemListenerTest.java
@@ -20,11 +20,10 @@ package org.pentaho.reporting.platform.plugin.async;
 import org.junit.Test;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 import org.pentaho.reporting.platform.plugin.MicroPlatformFactory;
+import org.pentaho.reporting.platform.plugin.cache.IReportContentCache;
 import org.pentaho.test.platform.engine.core.MicroPlatform;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class AsyncSystemListenerTest {
 
@@ -39,12 +38,25 @@ public class AsyncSystemListenerTest {
 
     final MicroPlatform microPlatform = MicroPlatformFactory.create();
     final IPentahoAsyncExecutor asyncExecutor = mock( IPentahoAsyncExecutor.class );
+    final IReportContentCache cache = mock( IReportContentCache.class );
     final AsyncSystemListener asyncSystemListener = new AsyncSystemListener();
     microPlatform.define( "IPentahoAsyncExecutor", asyncExecutor );
+    microPlatform.define( "IReportContentCache", cache );
     microPlatform.addLifecycleListener( asyncSystemListener );
     microPlatform.start();
     microPlatform.stop();
     verify( asyncExecutor, times( 1 ) ).shutdown();
+    verify( cache, times( 1 ) ).cleanup();
+  }
+
+
+  @Test
+  public void dontFailIfNoBeans() throws Exception {
+    final MicroPlatform microPlatform = MicroPlatformFactory.create();
+    final AsyncSystemListener asyncSystemListener = new AsyncSystemListener();
+    microPlatform.addLifecycleListener( asyncSystemListener );
+    microPlatform.start();
+    microPlatform.stop();
   }
 
 }

--- a/test-src/org/pentaho/reporting/platform/plugin/async/AutoScheduleListenerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/AutoScheduleListenerTest.java
@@ -1,0 +1,80 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License, version 2 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/gpl-2.0.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ *
+ * Copyright 2006 - 2016 Pentaho Corporation.  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin.async;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.pentaho.platform.api.engine.IPentahoSession;
+import org.pentaho.reporting.engine.classic.core.event.ReportProgressEvent;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@RunWith( Parameterized.class )
+public class AutoScheduleListenerTest {
+
+  public AutoScheduleListenerTest( final int threshold,
+                                   final ReportProgressEvent event, final int times ) {
+    this.threshold = threshold;
+    this.event = event;
+    this.times = times;
+  }
+
+  private int threshold;
+  private ReportProgressEvent event;
+  private int times;
+
+  @Parameterized.Parameters
+  public static Collection params() {
+    final ReportProgressEvent less = mock( ReportProgressEvent.class );
+    final ReportProgressEvent more = mock( ReportProgressEvent.class );
+    when( less.getMaximumRow() ).thenReturn( 0 );
+    when( more.getMaximumRow() ).thenReturn( Integer.MAX_VALUE );
+    return Arrays.asList( new Object[][] {
+      { 0, less, 0 },
+      { 0, more, 0 },
+      { 0, null, 0 },
+      { 1, less, 0 },
+      { 1, more, 1 },
+      { 1, null, 0 }
+    } );
+
+  }
+
+  @Test
+  public void testAutoSchedule() {
+
+    final UUID id = UUID.randomUUID();
+    final IPentahoSession session = mock( IPentahoSession.class );
+    final IPentahoAsyncExecutor executor = mock( IPentahoAsyncExecutor.class );
+    final AutoScheduleListener listener = new AutoScheduleListener( id, session, threshold, executor );
+    listener.reportProcessingStarted( event );
+    listener.reportProcessingUpdate( event );
+    listener.reportProcessingFinished( event );
+    verify( executor, times( times ) ).schedule( id, session );
+
+  }
+
+
+}
+

--- a/test-src/org/pentaho/reporting/platform/plugin/cache/DeleteOldOnAccessCacheTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/cache/DeleteOldOnAccessCacheTest.java
@@ -60,4 +60,14 @@ public class DeleteOldOnAccessCacheTest {
     assertNull( cache.get( SOME_KEY ) );
   }
 
+  @Test
+  public void testCleanup() throws Exception {
+    final DeleteOldOnAccessCache cache = new DeleteOldOnAccessCache( fileSystemCacheBackend );
+    cache.setMillisToLive( 1000 );
+    cache.put( SOME_KEY, SOME_VALUE );
+    assertNotNull( cache.get( SOME_KEY ) );
+    Thread.sleep( 2000 );
+    cache.cleanup();
+    assertNull( cache.get( SOME_KEY ) );
+  }
 }

--- a/test-src/org/pentaho/reporting/platform/plugin/cache/PluginSessionCacheTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/cache/PluginSessionCacheTest.java
@@ -29,9 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Test Session cache
@@ -83,19 +81,31 @@ public class PluginSessionCacheTest {
   }
 
 
-
   @Test
   public void testPutGetOrder() throws Exception {
     PentahoSessionHolder.setSession( new StandaloneSession( "test", "100500" ) );
     final IReportContentCache cache = new PluginSessionCache( fileSystemCacheBackend );
-    final Map<Integer, byte[]> map = new HashMap<>(  );
-    map.put( 0, new byte[] {1} );
-    map.put( 1, new byte[] {1, 2} );
-    cache.put( SOME_KEY,  new ReportContentImpl( 100, map ) );
+    final Map<Integer, byte[]> map = new HashMap<>();
+    map.put( 0, new byte[] { 1 } );
+    map.put( 1, new byte[] { 1, 2 } );
+    cache.put( SOME_KEY, new ReportContentImpl( 100, map ) );
     final IReportContent iReportContent = cache.get( SOME_KEY );
     assertNotNull( iReportContent );
     assertTrue( iReportContent.getPageData( 0 ).length == 1 );
     assertTrue( iReportContent.getPageData( 1 ).length == 2 );
+  }
+
+
+  @Test
+  public void testCleanup() throws Exception {
+    final StandaloneSession session = new StandaloneSession( "test", "100500" );
+    PentahoSessionHolder.setSession( session );
+
+    final IReportContentCache cache = new PluginSessionCache( fileSystemCacheBackend );
+    cache.put( SOME_KEY, SOME_VALUE );
+    assertNotNull( cache.get( SOME_KEY ) );
+    cache.cleanup();
+    assertNull( cache.get( SOME_KEY ) );
   }
 
 


### PR DESCRIPTION
We have several cases when cache files may not be cleaned up properly:

- cache for scheduled reports is not purged because we are already out of session scope
- errors may occur when trying to purge cache on logout

Let's add extra place to collect garbage - on platform stop.
Session cache is purget totally, time-based cache cleans only old files.

@tmorgner please take a look