### PR TITLE
[BACKLOG-8423] Cancel request is sent only once if dashboard mode is …

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -100,7 +100,10 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
         }));
 
         window.onbeforeunload = function(e) {
-          this.cancel(this._currentReportStatus, this._currentReportUuid);
+          // In dashboard mode if Edit capability is not loaded yet the page is reloaded in order to enter edit mode, no cancel request should be sent(no report changes were made)
+          if((window.frameElement.src.indexOf('dashboard-mode') !== -1 && parent.pho.dashboards.editMode) || window.frameElement.src.indexOf('dashboard-mode') == -1) {
+            this.cancel(this._currentReportStatus, this._currentReportUuid);
+          }
           if(window.top.mantle_removeHandler) {
             window.top.mantle_removeHandler(this._handlerRegistration);
           }


### PR DESCRIPTION
…changed

Instead of window.IsSwitchingToEditMode, I am checking pho.dashboards.editMode, similar to how it was done in dashboard plugin:
https://github.com/pentaho/pentaho-platform-plugin-dashboards/blob/master/resource/script/pentaho-dashboard-controller.js#L1810-L1813

@tmorgner 
Please review.