### PR TITLE
BACKLOG-8070 - Report page and page caching counter disappear when as…

### DIFF
--- a/package-res/reportviewer/reportviewer.js
+++ b/package-res/reportviewer/reportviewer.js
@@ -861,7 +861,8 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
 
         // PRD-3962 - remove glass pane after 5 seconds in case iframe onload/onreadystatechange was not detected
         me._updateReportTimeout = setTimeout(logged('updateReportTimeout', function() {
-          me._submitReportEnded(/*isTimeout*/true);
+          //BACKLOG-8070 don't show empty content in async mode
+          me._submitReportEnded( !me.reportPrompt._isAsync );
         }), 5000);
 
         // PRD-3962 - show glass pane on submit, hide when iframe is loaded.


### PR DESCRIPTION
…k not-cached page.

@tmorgner the fix is simple - we don't need to show empty content in async mode