### PR TITLE
CLEANUP - Fix naughty tests

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
+++ b/src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncExecutor.java
@@ -178,7 +178,7 @@ public class PentahoAsyncExecutor<TReportState extends IAsyncReportState>
     if ( !StringUtils.isEmpty( userId ) ) {
       if ( runningTask.schedule() ) {
         Futures.addCallback( future,
-          new TriggerScheduledContentWritingHandler( userId, sessionId, runningTask, compositeKey ) );
+          new TriggerScheduledContentWritingHandler( userId, sessionId, runningTask, compositeKey ), executorService );
         return true;
       }
     }

--- a/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
@@ -557,7 +557,7 @@ public class PentahoAsyncReportExecutorTest {
 
   @Test public void testUpdateSchedulingLocation() {
 
-    final PentahoAsyncExecutor exec = new PentahoAsyncExecutor( 1, autoSchedulerThreshold );
+    final PentahoAsyncExecutor exec = new PentahoAsyncExecutor( 10, autoSchedulerThreshold );
 
     final TestListener testListener = new TestListener( "1", UUID.randomUUID(), "" );
 
@@ -569,6 +569,12 @@ public class PentahoAsyncReportExecutorTest {
                                                           List<? extends ReportProgressListener> listeners ) {
         return testListener;
       }
+
+      @Override public synchronized boolean schedule() {
+        super.schedule();
+        return true;
+      }
+
     }, session1 );
 
     assertTrue( exec.schedule( id1, session1 ) );
@@ -656,6 +662,11 @@ public class PentahoAsyncReportExecutorTest {
       protected AsyncReportStatusListener createListener( final UUID id,
                                                           List<? extends ReportProgressListener> listeners ) {
         return testListener;
+      }
+
+      @Override public synchronized boolean schedule() {
+        super.schedule();
+        return true;
       }
     }, session1 );
 

--- a/test-src/org/pentaho/reporting/platform/plugin/cache/DeleteOldOnAccessCacheTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/cache/DeleteOldOnAccessCacheTest.java
@@ -24,11 +24,8 @@ import org.junit.Test;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.StandaloneSession;
 
-import java.io.Serializable;
 import java.util.Collections;
-import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -36,7 +33,6 @@ import static org.junit.Assert.assertNull;
 public class DeleteOldOnAccessCacheTest {
 
   private static final String SOME_KEY = "some_key";
-  private static final String SOME_METADATA_KEY = "some_metadata_key";
   private static final IReportContent SOME_VALUE =
     new ReportContentImpl( 100, Collections.singletonMap( 1, new byte[] { 1, 3, 4, 5 } ) );
   private static FileSystemCacheBackend fileSystemCacheBackend;
@@ -57,36 +53,21 @@ public class DeleteOldOnAccessCacheTest {
   public void testPutGet() throws Exception {
 
     final DeleteOldOnAccessCache cache = new DeleteOldOnAccessCache( fileSystemCacheBackend );
-    cache.setMillisToLive( 1000 );
+    cache.setDaysToLive( 1L );
     cache.put( SOME_KEY, SOME_VALUE );
     assertNotNull( cache.get( SOME_KEY ) );
-    Thread.sleep( 2500 );
+    cache.setMillisToLive( 0 );
     assertNull( cache.get( SOME_KEY ) );
   }
 
   @Test
   public void testCleanup() throws Exception {
     final DeleteOldOnAccessCache cache = new DeleteOldOnAccessCache( fileSystemCacheBackend );
-    cache.setMillisToLive( 1000 );
+    cache.setDaysToLive( 1L );
     cache.put( SOME_KEY, SOME_VALUE );
     assertNotNull( cache.get( SOME_KEY ) );
-    Thread.sleep( 2500 );
+    cache.setMillisToLive( 0 );
     cache.cleanup();
     assertNull( cache.get( SOME_KEY ) );
-  }
-
-  @Test
-  public void testPutGetWithMetaData() throws Exception {
-
-    final DeleteOldOnAccessCache cache = new DeleteOldOnAccessCache( fileSystemCacheBackend );
-    cache.setMillisToLive( 1000 );
-    final HashMap<String, Serializable> metadata = new HashMap<>();
-    metadata.put( SOME_METADATA_KEY, "test value" );
-    cache.put( SOME_KEY, SOME_VALUE, metadata );
-    assertNotNull( cache.get( SOME_KEY ) );
-    assertEquals( cache.getMetaData( SOME_KEY ).get( SOME_METADATA_KEY ), "test value" );
-    Thread.sleep( 2500 );
-    assertNull( cache.get( SOME_KEY ) );
-    assertNull( cache.getMetaData( SOME_KEY ) );
   }
 }


### PR DESCRIPTION
It seems that failing test showed a bug in executor. As far as I understand originally future callbacks were executed in the thread from wich they were added. From the guava code I found out that these callbacks lock the thread and simply wait for result. 

`addCallback(future, callback, MoreExecutors.sameThreadExecutor());`

We had a very bad situation when a bunch of long running scheduled reports could consume all threads from the tomcat thread pool and dramatically affect response time.

With the fix callbacks are now executed in our own thread pool.

@tmorgner please take a look.

