### PR TITLE
[BACKLOG-8501] - PIR: Sometimes message "The row limit has been reach…

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/output/PageableHTMLOutput.java
+++ b/src/org/pentaho/reporting/platform/plugin/output/PageableHTMLOutput.java
@@ -224,6 +224,8 @@ public class PageableHTMLOutput implements ReportOutputHandler {
           throw new ReportProcessingException( "Can't generate report" );
         }
 
+        listener.setIsQueryLimitReached( proc.isQueryLimitReached() );
+
         //Write all if scheduled
         if ( listener.isScheduled() ) {
           PaginationControlWrapper.write( outputStream, completeReport );


### PR DESCRIPTION
[BACKLOG-8501] - PIR: Sometimes message "The row limit has been reached" disappears when row limit is applied. 
3) in case async is enabled and caching is disabled the message does NOT appear (the issue is related to BACKLOG-7984.

@tmorgner 
Please review.