### PR TITLE
[BACKLOG-9668] - Post-processing computation is not working

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -485,9 +485,9 @@ public class ParameterXmlContentHandler {
           }
         }
 
-        // inspect post proc formulas, def values, etc.
-        computeNormalLineage( parameterContext, listParameter, downstreamParams );
       }
+      // inspect post proc formulas, def values, etc.
+      computeNormalLineage( parameterContext, entry, downstreamParams );
     }
 
     return downstreamParams;


### PR DESCRIPTION
All parameters can have formulas for post-processing and default-values, not only list parameters.