### PR TITLE
[BACKLOG-11519]-Ignore system row limit if row limit UI is disabled

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -428,8 +428,7 @@ public class ParameterXmlContentHandler {
       if ( pm != null ) {
         isQueryLimitControlEnabled = Boolean.parseBoolean(
           (String) pm.getPluginSetting( "reporting", "settings/query-limit-ui-enabled", "false" ) );
-        maxQueryLimit =
-          NumberUtils.toInt( (String) pm.getPluginSetting( "reporting", "settings/query-limit", "0" ), 0 );
+        maxQueryLimit = isQueryLimitControlEnabled ? NumberUtils.toInt( (String) pm.getPluginSetting( "reporting", "settings/query-limit", "0" ), 0 ) : 0;
       }
       inputs.put( SYS_PARAM_IS_QUERY_CONTROL_ENABLED, isQueryLimitControlEnabled );
       inputs.put( SYS_PARAM_REPORT_QUERY_LIMIT, report.getQueryLimit() );


### PR DESCRIPTION
Ignore any system row limit if the UI is disabled to avoid mess on client side.
@tmorgner please review