### PR TITLE
[BACKLOG-11570]-Allow to override row limit logic in PIR

### DIFF
--- a/src/org/pentaho/reporting/platform/plugin/SimpleReportingComponent.java
+++ b/src/org/pentaho/reporting/platform/plugin/SimpleReportingComponent.java
@@ -1079,7 +1079,7 @@ public class SimpleReportingComponent implements IStreamingPojo, IAcceptsRuntime
     }
   }
 
-  int checkAndGetUserInputQueryLimit( final Object userInputQueryLimit, final int reportQueryLimit ) {
+  protected int checkAndGetUserInputQueryLimit( final Object userInputQueryLimit, final int reportQueryLimit ) {
     int systemQueryLimit = 0;
 
     final IPluginManager pm = PentahoSystem.get( IPluginManager.class );


### PR DESCRIPTION
Reporting plugin messes it's configuration with PIR configuration.
We could check the inputs and detect that the request is from PIR but it's not very safe because user can pass any parameter from the UI and the code is in open source :)

Let's just add allow to override  the login in PIR itself.

@tmorgner please review