### PR TITLE
Backport of [BACKLOG-11526] - An arrow is absent on Row Limit drop-down.

### DIFF
--- a/package-res/reportviewer/report.html
+++ b/package-res/reportviewer/report.html
@@ -5,7 +5,8 @@
 
   <link rel="shortcut icon" href="images/favicon.ico" />
 
-  <link rel="stylesheet" type="text/css" href="../../../api/repos/common-ui/resources/web/dojo/dijit/themes/pentaho/pentaho.css"/>
+  <link rel="stylesheet" href="../../../api/repos/common-ui/resources/web/dojo/dijit/themes/pentaho/pentaho.css" type="text/css"/>
+  <link rel="stylesheet" href="../../../content/common-ui/resources/web/dojo/dijit/themes/pentaho/pentaho.css" type="text/css"/>
 
   <script type="text/javascript" src="webcontext.js?context=reporting"></script>
 
@@ -13,11 +14,9 @@
   <link rel="stylesheet" href="../../../content/pentaho-cdf/js/lib/jdMenu/jquery.jdMenu.slate.css" type="text/css" />
   <link rel="stylesheet" href="../../../content/pentaho-cdf/js/lib/impromptu/jquery-impromptu.css" type="text/css" />
 
-  <link rel="stylesheet" type="text/css" href="../../../content/common-ui/resources/web/dojo/dijit/themes/pentaho/pentaho.css"/>
   <link rel="stylesheet" href="../../../content/common-ui/resources/web/prompting/pentaho-prompting.css" type="text/css" />
   <link rel="stylesheet" href="../../../content/common-ui/resources/web/prompting/pentaho-prompting.css" type="text/css" />
-  <link href="../../../api/repos/common-ui/resources/web/dojo/pentaho/common/RowLimitControl.css" rel="stylesheet"
-      type="text/css"/>
+  <link rel="stylesheet" href="../../../content/common-ui/resources/web/dojo/pentaho/common/RowLimitControl.css" type="text/css"/>
   <link rel="stylesheet" href="../../../content/reporting/reportviewer/reportviewer.css" type="text/css" />
 
   <script type="text/javascript">


### PR DESCRIPTION
[BACKLOG-11526] - An arrow is absent on Row Limit drop-down.


Backport of https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/501

@tmorgner please review.