### PR TITLE
BISERVER-13170-Always send post-processing parameters values to the server

### DIFF
--- a/package-res/reportviewer/reportviewer-prompt.js
+++ b/package-res/reportviewer/reportviewer-prompt.js
@@ -299,10 +299,7 @@ define([
           if(oldParams){
             oldParams.mapParameters( function (p) {
               if(names && names.indexOf(p.name) >= 0){
-                //Don't need to request formulas
-                if(p && (!p.attributes || (p.attributes && !p.attributes['post-processor-formula']))){
                   needToUpdate.push(p.name);
-                }
               } else {
                 //Request update for invalid auto-fill parameters
                 if(p.attributes && oldParams.errors[p.name] && "true" === p.attributes['autofill-selection']){

--- a/src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -619,8 +619,10 @@ public class ParameterXmlContentHandler {
     if ( ( all != null ) && all.hasNext() ) {
       while ( all.hasNext() ) {
         final String nextName = all.next();
-        destination.add( nextName );
-        fillParams( destination, dependencies, nextName );
+        if ( !destination.contains( nextName ) ) {
+          destination.add( nextName );
+          fillParams( destination, dependencies, nextName );
+        }
       }
     }
   }

--- a/test-src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandlerTest.java
+++ b/test-src/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandlerTest.java
@@ -544,7 +544,15 @@ public class ParameterXmlContentHandlerTest {
 
     final HashNMap<String, String> dependencies = new HashNMap<>();
     dependencies.add( "first", "second" );
+    dependencies.add( "first", "fourth" );
     dependencies.add( "second", "third" );
+    dependencies.add( "third", "seventh" );
+    dependencies.add( "second", "fourth" );
+    //How about some cycles?
+    dependencies.add( "fourth", "third" );
+    dependencies.add( "third", "fourth" );
+    //Independent parameters
+    dependencies.add( "fifth", "sixth" );
 
     final Element parameters = handler.document.createElement( "parameters" );
     handler.document.appendChild( parameters );
@@ -587,10 +595,19 @@ public class ParameterXmlContentHandlerTest {
       new DefaultListParameter( "query", "c1", "c2", "third", true, true, String.class );
     final DefaultListParameter parameter3 =
       new DefaultListParameter( "query", "c1", "c2", "fourth", true, true, String.class );
+    final DefaultListParameter parameter4 =
+      new DefaultListParameter( "query", "c1", "c2", "fifth", true, true, String.class );
+    final DefaultListParameter parameter5 =
+      new DefaultListParameter( "query", "c1", "c2", "sixth", true, true, String.class );
+    final DefaultListParameter parameter6 =
+      new DefaultListParameter( "query", "c1", "c2", "seventh", true, true, String.class );
     parameterDefinitions.put( "first", parameter );
     parameterDefinitions.put( "second", parameter1 );
     parameterDefinitions.put( "third", parameter2 );
     parameterDefinitions.put( "fourth", parameter3 );
+    parameterDefinitions.put( "fifth", parameter4 );
+    parameterDefinitions.put( "sixth", parameter5 );
+    parameterDefinitions.put( "seventh", parameter6 );
     return parameterDefinitions;
   }
 
@@ -601,7 +618,7 @@ public class ParameterXmlContentHandlerTest {
     final Node minimized = root.item( 0 ).getAttributes().getNamedItem( "minimized" );
     assertNull( minimized );
     final NodeList nodeList = (NodeList) xpath.evaluate( "/parameters/parameter", doc, XPathConstants.NODESET );
-    assertEquals( 4, nodeList.getLength() );
+    assertEquals( 7, nodeList.getLength() );
     final NodeList first =
       (NodeList) xpath.evaluate( "/parameters/parameter[@name='first']", doc, XPathConstants.NODESET );
     assertEquals( 1, first.getLength() );
@@ -627,7 +644,7 @@ public class ParameterXmlContentHandlerTest {
     final Node minimized = root.item( 0 ).getAttributes().getNamedItem( "minimized" );
     assertNotNull( minimized );
     final NodeList nodeList = (NodeList) xpath.evaluate( "/parameters/parameter", doc, XPathConstants.NODESET );
-    assertEquals( 3, nodeList.getLength() );
+    assertEquals( 5, nodeList.getLength() );
     final NodeList first =
       (NodeList) xpath.evaluate( "/parameters/parameter[@name='first']", doc, XPathConstants.NODESET );
     assertEquals( 1, first.getLength() );
@@ -639,7 +656,16 @@ public class ParameterXmlContentHandlerTest {
     assertEquals( 1, third.getLength() );
     final NodeList fourth =
       (NodeList) xpath.evaluate( "/parameters/parameter[@name='fourth']", doc, XPathConstants.NODESET );
-    assertEquals( 0, fourth.getLength() );
+    assertEquals( 1, fourth.getLength() );
+    final NodeList fifth =
+      (NodeList) xpath.evaluate( "/parameters/parameter[@name='fifth']", doc, XPathConstants.NODESET );
+    assertEquals( 0, fifth.getLength() );
+    final NodeList sixth =
+      (NodeList) xpath.evaluate( "/parameters/parameter[@name='sixth']", doc, XPathConstants.NODESET );
+    assertEquals( 0, sixth.getLength() );
+    final NodeList seventh =
+      (NodeList) xpath.evaluate( "/parameters/parameter[@name='seventh']", doc, XPathConstants.NODESET );
+    assertEquals( 1, seventh.getLength() );
     final NodeList attributes = (NodeList) xpath.evaluate( "/parameters/parameter/attribute", doc, XPathConstants.NODESET );
     assertFalse( attributes.getLength() != 0 );
     final NodeList dependencies = (NodeList) xpath.evaluate( "/parameters/parameter/dependencies", doc, XPathConstants.NODESET );


### PR DESCRIPTION
The 1st commit (java code) is a fix for the stackowerflow which is a regression after Ewok's work.
The 2nd is actually the bug fix. We don't reload the PromptPanel after 6.1 and even don't send a request to server after 7.0, so to show valid value we need to go and set it through widget API.
I'm resetting datespickers only here but probably we want the same logic for other inputs as well.
Please pay attention to date parsing, I assume we always have date in ISO format there.


