### PR TITLE
[BISERVER-13569]-Compare values in datepicker parameters carefully

### DIFF
--- a/core/src/main/javascript/reportviewer/reportviewer-prompt.js
+++ b/core/src/main/javascript/reportviewer/reportviewer-prompt.js
@@ -651,19 +651,62 @@ define([
           }
         } else {
           //Working with a plain parameter
-          //Already has a valid value
           if (param.values[0].value === value) {
+            //Already has a valid value
             return;
           } else {
             //Datepickers require some extra care
             if (param.attributes['parameter-render-type'] === 'datepicker') {
+              var parameterValueStr = param.values[0].value;
+              //A regular expression for a common timezone format like a +3000
+              var tzRegex = /^.*[+-]{1}\d{4}$/;
+              //A regular expression for a tricky timezone without like a +09.530 or a +12.7545
+              var trickyTimezoneRegex = /(^.*[+-]{1}\d{2})(\.5|\.75)(\d{2}$)/;
+              //A parameter timezone hint
+              var timezoneHint = param.timezoneHint;
 
-              if (param.timezoneHint) {
-                value = value + param.timezoneHint.slice(1);
+
+              var processTimezone = function (processingValue) {
+                //Is a timezone present in a value?
+                var matchesArr = processingValue.match(tzRegex);
+                if (matchesArr && matchesArr.length > 0) {
+                  //A common timezone format
+                  return processingValue;
+                }
+                matchesArr = processingValue.match(trickyTimezoneRegex);
+                if (matchesArr && matchesArr.length === 4) {
+                  //A tricky timezone format
+                  return matchesArr[1] + matchesArr[3];
+                }
+
+                //Timezone is not found in a value, check the hint
+                if (timezoneHint) {
+                  //Timezone hint is present, apply it
+                  return processingValue + timezoneHint.slice(1);
+                }
+
+                //Nothing to do here
+                return processingValue;
+              };
+
+              value = processTimezone(value);
+              parameterValueStr = processTimezone(parameterValueStr);
+
+              //Erase seconds and milliseconds, minutes are needed to represent a timezone
+              var dtValue = new Date(value);
+              dtValue.setMilliseconds(0);
+              dtValue.setSeconds(0);
+
+              var dtParamValue = new Date(parameterValueStr);
+              dtParamValue.setMilliseconds(0);
+              dtParamValue.setSeconds(0);
+
+              if (isNaN(dtValue.getTime()) || isNaN(dtParamValue.getTime())) {
+                //Something went wrong we have an invalid date - don't loop the UI anyway
+                return;
               }
 
-              //We are comparing only the date, not the time
-              if ((new Date(value).setHours(0, 0, 0, 0)) === (new Date(param.values[0].value).setHours(0, 0, 0, 0))) {
+              if (dtValue.getTime() === dtParamValue.getTime()) {
                 //Already has a valid value
                 return;
               }


### PR DESCRIPTION
Enhanced the logic and covered it with tests.
There were several issues:
1) The timezone was added twice, when it was present in the value and the hint was aldo present.
2) Some Ausie and New Zeland timezones blowed things up. For some reason the format for 30/45 minutes timezones is different and not supported by JS dates. We have +09.530 and +11.7545 against regular +0930 and +1145 for Australian Nothern territory and NZ-CHAT timezones. By the way, the values with those timezones are not displayed in PUC ssatrting from a 6.1 GA. I've opend an issue PRD-5879
3) If the date is invalid we won't loop infinitely