### PR TITLE
[BACKLOG-15746] PRD - When a parameter uses a table datasource with a…

### DIFF
--- a/core/src/main/javascript/reportviewer/themes/sapphire/Sapphire.css
+++ b/core/src/main/javascript/reportviewer/themes/sapphire/Sapphire.css
@@ -102,7 +102,6 @@ div.prompt-panel div.parameter-label.parameter-label {
 #reportControlPanel select {
   overflow-y: auto;
   margin-bottom: 10px;
-  padding: 0 10px;
   line-height: 22px;
 }
 


### PR DESCRIPTION
… value list, the published report value list is broken

Removed padding which overrides global rule.

Should be merged together with https://github.com/pentaho/pentaho-commons-gwt-modules/pull/562
@pentaho/bobafett please review