### PR TITLE
[BACKLOG-17248] Fix images/CSS in single-page HTML reports generated in background

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/repository/ReportContentItem.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/repository/ReportContentItem.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin.repository;
@@ -110,6 +110,11 @@ public class ReportContentItem implements ContentItem {
   }
 
   public Object getContentId() {
-    return RepositoryPathEncoder.encode( file.getPath() );
+    // ':' is used instead of '/' as a separator to work around Spring Security.
+    // Since ':' is allowed in file/folder names in the repo, it is replaced with '\t' before changing the separator.
+    String path = file.getPath()
+            .replace( ':', '\t' )
+            .replace( '/', ':' );
+    return RepositoryPathEncoder.encode( path );
   }
 }

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/repository/ReportContentItemTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/repository/ReportContentItemTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin.repository;
@@ -52,8 +52,8 @@ public class ReportContentItemTest extends TestCase {
   }
 
   public void testGetContentId() throws Exception {
-    doReturn( "c:\\Dev\\" ).when( repositoryFile ).getPath();
-    String expectedResult = "c%3A%255CDev%255C";
+    doReturn( "/home/admin/namewithcolon:/picture118632338.png" ).when( repositoryFile ).getPath();
+    String expectedResult = "%3Ahome%3Aadmin%3Anamewithcolon%09%3Apicture118632338.png";
 
     assertEquals( expectedResult, reportContentItem.getContentId() );
   }


### PR DESCRIPTION
JIRA: http://jira.pentaho.com/browse/BACKLOG-17248

Changes the way repository paths are handled for `ReportContentItems` to work around Spring not allowing encoded slashes.