### PR TITLE
[BACKLOG-20957] Store images/css in the repository for pageable HTML output when the useJcr flag is set

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/SimpleReportingAction.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/SimpleReportingAction.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara.  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -873,8 +873,6 @@ public class SimpleReportingAction implements IStreamProcessingAction, IStreamin
         final Configuration configuration = report.getConfiguration();
         if ( configuration instanceof ModifiableConfiguration ) {
           final ModifiableConfiguration modifiableConfiguration = (ModifiableConfiguration) configuration;
-          //use tmp folder to store images and styles
-          setUseJcr( false );
           modifiableConfiguration.setConfigProperty( PentahoPlatformModule.FORCE_ALL_PAGES, "true" );
         }
       }

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/CachingPageableHTMLOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/CachingPageableHTMLOutput.java
@@ -235,7 +235,7 @@ public class CachingPageableHTMLOutput extends PageableHTMLOutput {
     }
   }
 
-  private boolean isJcrImagesAndCss() {
+  protected boolean isJcrImagesAndCss() {
     return getJcrOutputPath() != null && !getJcrOutputPath().isEmpty();
   }
 

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/DefaultReportOutputHandlerFactory.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/DefaultReportOutputHandlerFactory.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara.  All rights reserved.
  */
 package org.pentaho.reporting.platform.plugin.output;
 
@@ -528,6 +528,7 @@ public class DefaultReportOutputHandlerFactory implements ReportOutputHandlerFac
     if ( isCachePageableHtmlContentEnabled( selector.getReport() ) ) {
       final CachingPageableHTMLOutput pageableHTMLOutput = new CachingPageableHTMLOutput();
       pageableHTMLOutput.setContentHandlerPattern( contentHandlerPattern );
+      pageableHTMLOutput.setJcrOutputPath( selector.isUseJcrOutput() ? selector.getJcrOutputPath() : null );
       return pageableHTMLOutput;
     } else {
       final PageableHTMLOutput pageableHTMLOutput = new PageableHTMLOutput();


### PR DESCRIPTION
@pentaho/rogueone @tmorgner 

JIRA: https://jira.pentaho.com/browse/BACKLOG-20957

This PR modifies `CachingPageableHtmlOutput` to respect the useJcr flag. The `SimpleReportingAction` class was changed to enable this flag by default (so prpts that are run in the background will store images/css in JCR).

Storing related files in a folder with the prpt name was considered, but not implemented. Since images are reused if the report is cached, output may refer to images from an earlier run the prpt. If the cache is cleared, the images will not be deleted and duplicates will be added to the same folder.  This leads to same confusion as having no folder -- as long as images are reused between runs, the dependencies will be complex. This is really a stopgap solution. A long term solution is captured in [this ticket](https://jira.pentaho.com/browse/BACKLOG-21877).

If testing, the reporting cache will need to be cleared (Tools -> Refresh -> Reporting Data Cache). If it is not cleared, any report that have been run with pageable html output will fail. 