### PR TITLE
[PRD-5963] - Date Picker showing One Day Prior for Default Value of =…

### DIFF
--- a/core/src/main/javascript/reportviewer/reportviewer-formatting.js
+++ b/core/src/main/javascript/reportviewer/reportviewer-formatting.js
@@ -212,6 +212,30 @@ define(['reportviewer/reportviewer-timeutil'], function(ReportTimeUtil) {
           }
 
           if(timezone == 'client') {
+
+              if (value.length == 28) {
+
+                  var currentDate = new Date();
+                  var offset = -currentDate.getTimezoneOffset();
+
+                  // calculation is done in minutes because it is the smaller unit on a timezone definition
+                  // e.g.: "2018-05-20T01:12:23.456-0430" where -04h30m is the timezone setting
+                  var offsetServerMinutes = value.substring(23, 26) * 60;
+                  var diffOffset = offset - offsetServerMinutes;
+
+                  if(diffOffset != 0){
+                      this._initDateFormatters();
+
+                      var currentMinutes = ( currentDate.getHours() * 60 ) + currentDate.getMinutes();
+
+                      var diffMinutes = currentMinutes - diffOffset;
+                      var localDate = this.parseDateWithoutTimezoneInfo(value);
+                      var dayVariance = (diffMinutes < 0) ? 1 : (diffMinutes >= 1440) ? -1 : 0;
+
+                      var dayVarianceApplied = localDate.setDate(localDate.getDate() + dayVariance);
+                      return this.dateFormatters['with-timezone'].format(new Date(dayVarianceApplied));
+                  }
+              }
             return value;
           }
 

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
@@ -1,0 +1,79 @@
+/*!
+ * This program is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
+ * Foundation.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with this
+ * program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+ * or from the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details.
+ *
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ */
+
+package org.pentaho.reporting.platform.plugin;
+
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.pentaho.reporting.engine.classic.core.parameters.ParameterAttributeNames;
+import org.pentaho.reporting.engine.classic.core.parameters.ParameterContext;
+import org.pentaho.reporting.engine.classic.core.parameters.ParameterDefinitionEntry;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class ReportContentUtilTest {
+
+  @Mock private ParameterContext context;
+
+  private ParameterDefinitionEntry pde = Mockito.mock( ParameterDefinitionEntry.class );
+
+  @Test
+  public void parseDateStrict_null_Test() throws Exception {
+
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+            ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( null );
+
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 01:12:23 UTC 2018" );
+  }
+
+  @Test
+  public void parseDateStrict_GMTplus3_Test() throws Exception {
+
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+            ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT+3" );
+
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 04:12:23 UTC 2018" );
+  }
+
+  @Test
+  public void parseDateStrict_GMTminus7_Test() throws Exception {
+
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+            ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT-7" );
+
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sat May 19 18:12:23 UTC 2018" );
+  }
+
+  @Test
+  public void parseDateStrict_server_Test() throws Exception {
+
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+            ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "client" );
+
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 01:12:23 UTC 2018" );
+  }
+
+  private void validateParseDateStrict( final String dateToParse, final String dateResult ) throws Exception {
+
+    Date date = ReportContentUtil.parseDateStrict( pde, context, dateToParse );
+    assertEquals( dateResult, date.toString() );
+  }
+}


### PR DESCRIPTION
…TODAY and =YESTERDAY when client is in Different Timezone

   * Added client side support to handle reports which date is calculated based on client timezone
   * Refactored the date parser based on timezone type value, which can be one of the following:
    1) server - timezone already handled by the server
    2) client - timezone handled in the client side (see pentaho-platform-plugin-common-ui - formatting.js)
    3) utc - timezone forced to UTC
    4) customized timezone - timezone forced to customized timezone