### PR TITLE
[BISERVER-13775] PUC-Unable to generate report in Excel

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/SimpleReportingComponent.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/SimpleReportingComponent.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -30,6 +30,7 @@ import org.pentaho.reporting.engine.classic.core.AttributeNames;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.ReportDataFactoryException;
 import org.pentaho.reporting.engine.classic.core.ReportInterruptedException;
+import org.pentaho.reporting.engine.classic.core.ReportProcessingException;
 import org.pentaho.reporting.engine.classic.core.metadata.ReportProcessTaskRegistry;
 import org.pentaho.reporting.engine.classic.core.modules.output.pageable.pdf.PdfPageableModule;
 import org.pentaho.reporting.engine.classic.core.modules.output.pageable.plaintext.PlainTextPageableModule;
@@ -970,6 +971,9 @@ public class SimpleReportingComponent implements IStreamingPojo, IAcceptsRuntime
       log.info( "Report execution interrupted." );
     } catch ( Exception e ) {
       log.error( Messages.getInstance().getString( "ReportPlugin.executionFailed" ), e ); //$NON-NLS-1$
+      if ( e instanceof ReportProcessingException ) {
+        throw e;
+      }
     }
     // lets not pretend we were successfull, if the export type was not a valid one.
     return false;

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecution.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2017 Hitachi Vantara.  All rights reserved.
+ * Copyright 2006 - 2018 Hitachi Vantara.  All rights reserved.
  */
 
 
@@ -126,7 +126,15 @@ public class PentahoAsyncReportExecution extends AbstractAsyncReportExecution<IA
           log.error( "fail to execute report in async mode: " + ee );
 
           if ( ee.getMessage() != null ) {
-            listener.setErrorMessage( ee.getMessage() );
+            String errorMessage = "";
+            Throwable throwable = ee;
+
+            while ( throwable != null ) {
+              errorMessage += throwable.getMessage() + ".\n";
+              throwable = throwable.getCause();
+            }
+
+            listener.setErrorMessage( errorMessage );
           }
           fail();
           return NULL;


### PR DESCRIPTION
This wasn't actually a bug. In Excel 97, the maximum number of allowed rows is 65536. If the file is bigger, it is impossible to generate a proper excel file.  Before the ReportProcessingException was silenced during execution, but now the exception is thrown. Moreover, to give a more descriptive error message, all cascading exceptions' error messages are included.  

Instead of: "Request failed"
The error message is:
 " Failed to process the report.
    Other failure.
    Invalid row number (65536) outside allowable range (0..65535).
 "

@pamval @duarteteixeira 
@pentaho-lmartins @ricardosilva88 