### PR TITLE
[PRD-2034] - Dashboard refresh error "pentaho-ajax.js.pentahoResponse…

### DIFF
--- a/core/src/main/javascript/reportviewer/reportviewer.js
+++ b/core/src/main/javascript/reportviewer/reportviewer.js
@@ -996,7 +996,9 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
 
       _hideAsyncScreens: function(){
         registry.byId('reportGlassPane').hide();
-        domClass.add('notification-screen', 'hidden');
+        if(domClass && domClass.className) {
+          domClass.add('notification-screen', 'hidden');
+        }
       },
 
       _submitRowLimitUpdate: function (selectedLimit) {


### PR DESCRIPTION
…(): TypeError: Cannot read property 'className' of null"

During intense report refresh, with times between 1 and 2 seconds time to refresh (when inside a dashboard), domClass may become null for a fraction of time, which causes the error - "pentaho-ajax.js.pentahoResponse(): TypeError: Cannot read property 'className' of null"