### PR TITLE
[SP-4688] Backport of PIR-1414 - Report does not render complete data…

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/SimpleReportingAction.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/SimpleReportingAction.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -503,6 +503,7 @@ public class SimpleReportingAction implements IStreamProcessingAction, IStreamin
     } catch ( Throwable t ) {
       log.warn( t.getMessage(), t );
     }
+    report.setQueryLimit( -1 );
     return report;
   }
 

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/SimpleReportingActionTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/SimpleReportingActionTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2016 Pentaho Corporation..  All rights reserved.
+ * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -198,6 +198,16 @@ public class SimpleReportingActionTest {
     sra.setVarArgs( inputs );
     sra.setReport( report );
     assertEquals( report, sra.getReport() );
+  }
+
+  @Test
+  public void testGetReportQueryLimit() throws Exception {
+
+    MasterReport report = new MasterReport();
+    report.setQueryLimit( 10 );
+    assertEquals( 10, report.getQueryLimit() );
+    sra.setReport( report );
+    assertEquals( -1, sra.getReport().getQueryLimit() );
   }
 
   @Test


### PR DESCRIPTION
… when Query Limit, Design Query limit are set and exported via Schedule/Run in Background (7.1 Suite)

@smmribeiro @LeonardoCoelho71950 