### PR TITLE
[BISERVER-13901] When auto-submit is off, the report parameter/prompt panel flashes/gl…

### DIFF
--- a/core/src/main/javascript/reportviewer/reportviewer-prompt.js
+++ b/core/src/main/javascript/reportviewer/reportviewer-prompt.js
@@ -27,7 +27,7 @@ define([
   "common-ui/util/formatting"
 ], function(util, Messages, registry, PromptingAPI, $, _, Utils, domClass, FormatUtils) {
 
-  var _api =  new PromptingAPI('promptPanel');
+  var _api =  new PromptingAPI('promptPanel', { isSilent:true } );
 
   return function() {
     return logged({


### PR DESCRIPTION
…ass pane appears when parameter is TEXT field.

Depends on https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1382

@pentaho/tatooine @pentaho-lmartins  
@dcleao 