### PR TITLE
 [PRD-6070] Date Picker showing incorrect value when client is in different day due to Timezone difference

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -552,7 +552,7 @@ public class ParameterXmlContentHandler {
       final ParameterContextWrapper wrapper =
         new ParameterContextWrapper( parameterContext, vr.getParameterValues() );
       final Element el = createParameterElement( parameter, wrapper, selections, dependencies, ignoreAttributes );
-      if ( !ignoreAttributes ) {
+      if ( !ignoreAttributes || ReportContentUtil.isDateParameter( parameter ) ) {
         createParameterDependencies( el, parameter, dependencies );
       }
       parameters.appendChild( el );

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
@@ -24,9 +24,13 @@ import org.pentaho.reporting.engine.classic.core.parameters.ParameterAttributeNa
 import org.pentaho.reporting.engine.classic.core.parameters.ParameterContext;
 import org.pentaho.reporting.engine.classic.core.parameters.ParameterDefinitionEntry;
 
+import java.sql.Time;
+import java.sql.Timestamp;
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 public class ReportContentUtilTest {
@@ -72,6 +76,41 @@ public class ReportContentUtilTest {
       ParameterAttributeNames.Core.DATA_FORMAT, null ) ).thenReturn( "yyyy-MM-dd" );
 
     validateParseDateStrict( "2018-05-20T00:00:00.000-0400", "Sun May 20 00:00:00 UTC 2018" );
+  }
+
+  @Test
+  public void isDateParameterTestNullParameter() {
+    assertFalse( ReportContentUtil.isDateParameter( null ) );
+  }
+
+  @Test
+  public void isDateParameterTestInvalidClassType() {
+    when( pde.getValueType() ).thenReturn( ReportContentUtil.class );
+    assertFalse( ReportContentUtil.isDateParameter( pde ) );
+  }
+
+  @Test
+  public void isDateParameterTestSqlDateValueType() {
+    when( pde.getValueType() ).thenReturn( java.sql.Date.class );
+    assertTrue( ReportContentUtil.isDateParameter( pde ) );
+  }
+
+  @Test
+  public void isDateParameterTestTimestampValueType() {
+    when( pde.getValueType() ).thenReturn( Timestamp.class );
+    assertTrue( ReportContentUtil.isDateParameter( pde ) );
+  }
+
+  @Test
+  public void isDateParameterTestTimeValueType() {
+    when( pde.getValueType() ).thenReturn( Time.class );
+    assertTrue( ReportContentUtil.isDateParameter( pde ) );
+  }
+
+  @Test
+  public void isDateParameterTestDateValueType() {
+    when( pde.getValueType() ).thenReturn( Date.class );
+    assertTrue( ReportContentUtil.isDateParameter( pde ) );
   }
 
   private void validateParseDateStrict( final String dateToParse, final String dateResult ) throws Exception {

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -31,52 +31,52 @@ import static org.mockito.Mockito.when;
 
 public class ReportContentUtilTest {
 
-    @Mock private ParameterContext context;
+  @Mock private ParameterContext context;
 
-    private ParameterDefinitionEntry pde = Mockito.mock( ParameterDefinitionEntry.class );
+  private ParameterDefinitionEntry pde = Mockito.mock( ParameterDefinitionEntry.class );
 
-    @Test
-    public void parseDateStrict_null_Test() throws Exception {
+  @Test
+  public void parseDateStrict_null_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( null );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( null );
 
-        validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 01:12:23 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 01:12:23 UTC 2018" );
+  }
 
-    @Test
-    public void parseDateStrict_GMTplus3_Test() throws Exception {
+  @Test
+  public void parseDateStrict_GMTplus3_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT+3" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT+3" );
 
-        validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 04:12:23 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 04:12:23 UTC 2018" );
+  }
 
-    @Test
-    public void parseDateStrict_GMTminus7_Test() throws Exception {
+  @Test
+  public void parseDateStrict_GMTminus7_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT-7" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT-7" );
 
-        validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sat May 19 18:12:23 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sat May 19 18:12:23 UTC 2018" );
+  }
 
-    @Test
-    public void parseDateStrict_server_Test() throws Exception {
+  @Test
+  public void parseDateStrict_server_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "client" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "client" );
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.DATA_FORMAT, null ) ).thenReturn( "yyyy-MM-dd" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.DATA_FORMAT, null ) ).thenReturn( "yyyy-MM-dd" );
 
-        validateParseDateStrict( "2018-05-20T00:00:00.000-0400", "Sun May 20 00:00:00 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T00:00:00.000-0400", "Sun May 20 00:00:00 UTC 2018" );
+  }
 
-    private void validateParseDateStrict( final String dateToParse, final String dateResult ) throws Exception {
+  private void validateParseDateStrict( final String dateToParse, final String dateResult ) throws Exception {
 
-        Date date = ReportContentUtil.parseDateStrict( pde, context, dateToParse );
-        assertEquals( dateResult, date.toString() );
-    }
+    Date date = ReportContentUtil.parseDateStrict( pde, context, dateToParse );
+    assertEquals( dateResult, date.toString() );
+  }
 }


### PR DESCRIPTION
This is one part of 3 PRs for this issue.
The other are:
https://github.com/pentaho/pentaho-reporting/pull/1282
https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1443

@pentaho-lmartins @pentaho/tatooine 