### PR TITLE
[SP-5131] Backport of PRD-6031 - Exporting a report in Excel via IE gives the filename as "content" instead of giving the prpt's name as filename (8.3 Suite)

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/JobManager.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/JobManager.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2018 Hitachi Vantara.  All rights reserved.
+ * Copyright 2006 - 2019 Hitachi Vantara.  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -61,6 +61,11 @@ import java.util.concurrent.Future;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.pentaho.platform.util.web.MimeHelper.MIMETYPE_CSV;
+import static org.pentaho.platform.util.web.MimeHelper.MIMETYPE_EMAIL_MSG;
+import static org.pentaho.platform.util.web.MimeHelper.MIMETYPE_MS_EXCEL_2007;
+import static org.pentaho.platform.util.web.MimeHelper.MIMETYPE_MS_EXCEL;
+import static org.pentaho.platform.util.web.MimeHelper.MIMETYPE_RTF;
 
 @Path( "/reporting/api/jobs" )
 public class JobManager {
@@ -348,7 +353,8 @@ public class JobManager {
     final org.pentaho.reporting.libraries.base.util.IOUtils utils = org.pentaho.reporting.libraries
       .base.util.IOUtils.getInstance();
 
-    final String targetExt = MimeHelper.getExtension( state.getMimeType() );
+    final String mimeType = state.getMimeType();
+    final String targetExt = MimeHelper.getExtension( mimeType );
     final String fullPath = state.getPath();
     final String sourceExt = utils.getFileExtension( fullPath );
     String cleanFileName = utils.stripFileExtension( utils.getFileName( fullPath ) );
@@ -358,13 +364,40 @@ public class JobManager {
 
     final String
       disposition =
-      "inline; filename*=UTF-8''" + RepositoryPathEncoder
+      getDispositionType( mimeType ) + " filename*=UTF-8''" + RepositoryPathEncoder
         .encode( RepositoryPathEncoder.encodeRepositoryPath( cleanFileName + targetExt ) );
     response.header( "Content-Disposition", disposition );
 
     response.header( "Content-Description", cleanFileName + sourceExt );
 
     return response;
+  }
+
+  protected static String getDispositionType( String mimeType ) {
+    /*
+     * [PRD-6031]
+     * Some files cannot be done inline and have to be forced to be downloaded. In most browsers this can be handled
+     * automatically (whether you set inline or attachment), but browsers such as IE7/8/11 cannot handle this
+     * appropriately and will show the legacy Open/Save/Save As dialog, which loses the focus of the filename provided
+     * in the response message. This is because Internet Explorer's design does not allow inline and filename to work
+     * together for some files. It appears these files are files that can be opened using the Microsoft Office framework
+     * (Outlook, Excel, Word). What does work is to specifically call out attachment and filename, then IE will use the
+     * newer Open/Save/Save As dialog, which does capture the filename appropriately. This switch statement also works
+     * in Firefox, Opera, and Google Chrome.
+     */
+    String dispositionType;
+    switch ( mimeType ) {
+      case MIMETYPE_EMAIL_MSG:
+      case MIMETYPE_MS_EXCEL:
+      case MIMETYPE_MS_EXCEL_2007:
+      case MIMETYPE_CSV:
+      case MIMETYPE_RTF:
+        dispositionType = "attachment;";
+        break;
+      default:
+        dispositionType = "inline;";
+    }
+    return dispositionType;
   }
 
   @JsonPropertyOrder( alphabetic = true ) //stable response structure

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/JobManagerTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/JobManagerTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2018 Hitachi Vantara.  All rights reserved.
+ * Copyright 2006 - 2019 Hitachi Vantara.  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -32,6 +32,7 @@ import org.pentaho.platform.api.repository2.unified.IUnifiedRepository;
 import org.pentaho.platform.api.repository2.unified.RepositoryFile;
 import org.pentaho.platform.engine.core.system.PentahoSessionHolder;
 import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.platform.util.web.MimeHelper;
 import org.pentaho.reporting.platform.plugin.async.AsyncExecutionStatus;
 import org.pentaho.reporting.platform.plugin.async.AsyncReportState;
 import org.pentaho.reporting.platform.plugin.async.IAsyncReportState;
@@ -148,21 +149,37 @@ public class JobManagerTest {
 
   @Test
   public void calculateContentDisposition() throws Exception {
-    final IAsyncReportState state =
+    final IAsyncReportState state1 =
       new AsyncReportState( UUID.randomUUID(), "/somepath/anotherlevel/file.prpt", AsyncExecutionStatus.FINISHED, 0, 0,
-        0, 0, 0, 0, "", "text/csv", "", false );
+        0, 0, 0, 0, "", MimeHelper.MIMETYPE_CSV, "", false );
 
-    final Response.ResponseBuilder builder = mock( Response.ResponseBuilder.class );
+    final Response.ResponseBuilder builder1 = mock( Response.ResponseBuilder.class );
 
-    JobManager.calculateContentDisposition( builder, state );
+    JobManager.calculateContentDisposition( builder1, state1 );
 
-    ArgumentCaptor<String> argument = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> argument = ArgumentCaptor.forClass( String.class );
 
-    verify( builder, times( 1 )).header( eq( "Content-Description" ), argument.capture() );
+    verify( builder1, times( 1 ) ).header( eq( "Content-Description" ), argument.capture() );
     assertTrue( argument.getValue().contains( "file.prpt" ) );
 
-    verify( builder, times( 1 )).header( eq( "Content-Disposition" ), argument.capture() );
-    assertTrue( argument.getValue().contains( "inline; filename*=UTF-8''file.csv" ) );
+    verify( builder1, times( 1 ) ).header( eq( "Content-Disposition" ), argument.capture() );
+    assertTrue( argument.getValue().contains( "attachment; filename*=UTF-8''file.csv" ) );
+
+    final IAsyncReportState state2 =
+      new AsyncReportState( UUID.randomUUID(), "/somepath/anotherlevel/file.prpt", AsyncExecutionStatus.FINISHED, 0, 0,
+        0, 0, 0, 0, "", MimeHelper.MIMETYPE_PDF, "", false );
+
+    final Response.ResponseBuilder builder2 = mock( Response.ResponseBuilder.class );
+
+    JobManager.calculateContentDisposition( builder2, state2 );
+
+    argument = ArgumentCaptor.forClass( String.class );
+
+    verify( builder2, times( 1 ) ).header( eq( "Content-Description" ), argument.capture() );
+    assertTrue( argument.getValue().contains( "file.prpt" ) );
+
+    verify( builder2, times( 1 ) ).header( eq( "Content-Disposition" ), argument.capture() );
+    assertTrue( argument.getValue().contains( "inline; filename*=UTF-8''file.pdf" ) );
   }
 
 


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @LeonardoCoelho71950 

Part of a set of 2 PRs related to SP-5131:
- https://github.com/pentaho/pentaho-platform/pull/4492
- https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/734