### PR TITLE
[BISERVER-14306] Multi Value List parameter values are reset after changing output type in a prpt report

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -377,6 +377,21 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>javascript-test_karma</id>
+            <goals>
+              <goal>karma</goal>
+            </goals>
+            <configuration>
+              <workingDirectory>${project.basedir}/..</workingDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -547,7 +547,7 @@ public class ParameterXmlContentHandler {
                                    final Map<String, Object> inputs,
                                    final boolean ignoreAttributes ) throws BeanException, ReportDataFactoryException {
     for ( final ParameterDefinitionEntry parameter : reportParameters ) {
-      final Object selections = getSelections( parameter, changedParameters, inputs );
+      final Object selections = getSelections( parameter, changedParameters, dependencies, inputs );
 
       final ParameterContextWrapper wrapper =
         new ParameterContextWrapper( parameterContext, vr.getParameterValues() );
@@ -561,6 +561,7 @@ public class ParameterXmlContentHandler {
 
   protected Object getSelections( final ParameterDefinitionEntry parameter,
                                   final Set<String> changedParameters,
+                                  final ParameterDependencyGraph dependencies,
                                   final Map<String, Object> inputs ) {
     Objects.requireNonNull( changedParameters );
     Objects.requireNonNull( parameter );
@@ -583,7 +584,11 @@ public class ParameterXmlContentHandler {
 
     // otherwise the parameter is dependent and the selections are outdated
     final boolean ifChangedParameter = changedParameters.contains( pName );
-    return isVerifiedValue || ifChangedParameter ? inputs.get( pName ) : null;
+
+    // Need to also check if the parameter is a dependency, if it isn't a dependency, no need to reset selection
+    final boolean isDependency = dependencies.doesDependencyExist( pName );
+
+    return isVerifiedValue || ifChangedParameter || !isDependency ? inputs.get( pName ) : null;
   }
 
   private Set<String> filterRedundantParameter( final Set<String> changedParameters,
@@ -747,7 +752,7 @@ public class ParameterXmlContentHandler {
 
         //parameter dependencies: see backlog-7980
         boolean shouldValidateOnServer =
-          !dependencies.isNoDependencyInformationAvailable()
+          !dependencies.getDependencyGraph().isEmpty()
             || shouldAlwaysValidateOnServer( parameter, parameterContext );
         final Set<String> dependentParams = dependencies.getDependentParameterFor( parameter.getName() );
         if ( !dependentParams.isEmpty() ) {

--- a/core/src/main/javascript/reportviewer/reportviewer-prompt.js
+++ b/core/src/main/javascript/reportviewer/reportviewer-prompt.js
@@ -652,7 +652,11 @@ define([
           var counter = 0;
           for (var i in param.values) {
             var paramVal = param.values[i];
-            if (value.indexOf(paramVal.value) > -1) {
+            if (value.indexOf(paramVal.value) > -1
+              //Datepickers require some extra care (this is needed if the values list has a stored default value and
+              // keeps it ready and selected=false.)
+              || (param.attributes['parameter-render-type'] === 'datepicker'
+                && this._compareDatesOnly(paramVal.value, value[0], param.timezoneHint, this._createFormatter(param)))) {
               if (!paramVal.selected) {
                 paramVal.selected = true;
                 counter++;
@@ -715,7 +719,6 @@ define([
 
             //Timezone is not found in a value, check the hint
             if (timezoneHint) {
-              timezoneHint = timezoneHint.replace("/\\+/", "+"); //remove illegal format "\+xxxx" for timezone
               //Timezone hint is present, apply it
               return processingValue + timezoneHint;
             }

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/ParameterDependencyGraphTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/ParameterDependencyGraphTest.java
@@ -13,7 +13,7 @@
  * See the GNU General Public License for more details.
  *
  *
- * Copyright 2006 - 2018 Hitachi Vantara.  All rights reserved.
+ * Copyright 2006 - 2019 Hitachi Vantara.  All rights reserved.
  */
 package org.pentaho.reporting.platform.plugin;
 
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Set;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ParameterDependencyGraphTest {
 
@@ -33,29 +35,31 @@ public class ParameterDependencyGraphTest {
 
   @Test
   public void testGetDependentParameterFor() {
-    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph( true, "param1", "param2" );
+    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph( "param1", "param2" );
     assertEquals( paramDepGrap.getDependentParameterFor( "param1" ), asSet() );
 
-    paramDepGrap.setNoDependencyInformationAvailable( false );
+    paramDepGrap.setDependencyInformationAvailable( true );
     LinkedHashMap<String, Set<String>> dependencyGraph = new LinkedHashMap<>();
     dependencyGraph.put( "param1", asSet( "param2", "param3" ) );
     paramDepGrap.setDependencyGraph( dependencyGraph );
     assertEquals( paramDepGrap.getDependentParameterFor( "param1" ), asSet( "param2", "param3" ) );
+    paramDepGrap.setDependencyInformationAvailable( false );
     assertEquals( paramDepGrap.getDependentParameterFor( "param2" ), Collections.emptySet() );
   }
 
   @Test
   public void testGetAllDependencies() {
-    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph( true, "param1", "param2" );
+    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph( "param1", "param2" );
+    paramDepGrap.setDependencyInformationAvailable( false );
     assertEquals( paramDepGrap.getAllDependencies( "param1" ), asSet( "param1", "param2" ) );
 
-    paramDepGrap.setNoDependencyInformationAvailable( false );
+    paramDepGrap.setDependencyInformationAvailable( true );
     assertEquals( paramDepGrap.getAllDependencies( asSet( "param1", "param1" ) ), Collections.emptySet() );
   }
 
   @Test
   public void testGetKnownParameter() {
-    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph( true );
+    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph();
     LinkedHashMap<String, Set<String>> dependencyGraph = new LinkedHashMap<>();
     dependencyGraph.put( "param1", asSet( "param2", "param3" ) );
     dependencyGraph.put( "param2", asSet( "param3", "param4" ) );
@@ -66,7 +70,7 @@ public class ParameterDependencyGraphTest {
 
   @Test
   public void testAddDependency() {
-    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph( true );
+    ParameterDependencyGraph paramDepGrap = new ParameterDependencyGraph();
     LinkedHashMap<String, Set<String>> dependencyGraph = new LinkedHashMap<>();
     dependencyGraph.put( "param1", asSet( "param2", "param3" ) );
     dependencyGraph.put( "param2", asSet( "param3", "param4" ) );
@@ -76,4 +80,29 @@ public class ParameterDependencyGraphTest {
     assertEquals( paramDepGrap.getKnownParameter(), asSet( "param1", "param2", "param3" ) );
   }
 
+  @Test
+  public void testDoesDependencyExist() {
+    final ParameterDependencyGraph dependencyGraph = new ParameterDependencyGraph( "param1",
+      "param2", "param3" );
+    assertFalse( dependencyGraph.doesDependencyExist( "param2" ) );
+    dependencyGraph.addDependency( "param1", "param2" );
+    assertTrue( dependencyGraph.doesDependencyExist( "param2" ) );
+  }
+
+  @Test
+  public void testGetAllParameterNames() {
+    Set<String> paramSet = new HashSet<>();
+    paramSet.add( "param1" );
+    paramSet.add( "param2" );
+    paramSet.add( "param3" );
+
+    final ParameterDependencyGraph dependencyGraph = new ParameterDependencyGraph( "param1",
+      "param2", "param3" );
+    assertEquals( paramSet, dependencyGraph.getAllParameterNames() );
+
+    paramSet.add( "param4" );
+    dependencyGraph.setAllParameterNames( paramSet );
+    assertEquals( paramSet, dependencyGraph.getAllParameterNames() );
+
+  }
 }

--- a/core/src/test/javascript/reportviewer-prompt-spec.js
+++ b/core/src/test/javascript/reportviewer-prompt-spec.js
@@ -352,7 +352,8 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
         });
 
         it("should not force an update if the single selection value is not changed", function () {
-          var param = {values: [{value: "test", selected: true}, {value: "test1"}]};
+          var param = {values: [{value: "test", selected: true}, {value: "test1"}],
+            attributes: {'parameter-render-type': 'list'}};
           reportPrompt._applyUserInput("anyname", "test", param);
           expect(reportPrompt.forceUpdate).toBe(undefined);
         });
@@ -363,7 +364,8 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
               {value: "test", selected: true},
               {value: "test1", selected: true},
               {value: "test2"}
-            ]
+            ],
+            attributes: {'parameter-render-type': 'list'}
           };
           reportPrompt._applyUserInput("anyname", ["test", "test1"], parameter);
           expect(parameter.forceUpdate).toBe(undefined);
@@ -376,7 +378,8 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
         });
 
         it("should force an update if the single selection value is changed", function () {
-          var param = {values: [{value: "test", selected: true}, {value: "test1"}]};
+          var param = {values: [{value: "test", selected: true}, {value: "test1"}],
+            attributes: {'parameter-render-type': 'list'}};
           reportPrompt._applyUserInput("anyname", "test1", param);
           expect(param.forceUpdate).toBe(true);
         });
@@ -387,7 +390,8 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
               {value: "test", selected: true},
               {value: "test1", selected: true},
               {value: "test2"}
-            ]
+            ],
+            attributes: {'parameter-render-type': 'list'}
           };
           reportPrompt._applyUserInput("anyname", ["test", "test2"], parameter);
           expect(parameter.forceUpdate).toBe(true);
@@ -399,7 +403,8 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
               {value: "test", selected: true},
               {value: "test1", selected: true},
               {value: "test2"}
-            ]
+            ],
+            attributes: {'parameter-render-type': 'list'}
           };
           reportPrompt._applyUserInput("anyname", ["test"], parameter);
           expect(parameter.forceUpdate).toBe(true);
@@ -408,10 +413,47 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
               {value: "test", selected: true},
               {value: "test1", selected: true},
               {value: "test2"}
-            ]
+            ],
+            attributes: {'parameter-render-type': 'list'}
           };
           reportPrompt._applyUserInput("anyname", ["test", "test1", "test2"], parameter);
           expect(parameter.forceUpdate).toBe(true);
+        });
+
+        // [BISERVER-14306]
+        // These 2 tests only occur in code when there's a default value for a Date object.  The selection goes through
+        // A loop to first remove the bad date and then adds the new date value. Code was updated to handle the forced
+        // deselection of the old date.
+        it("should force an update if the date selection value has a different number of selections", function () {
+          var dateSelectionParameter = {
+            values: [
+              {value: "2019-09-13", selected: false},
+              {value: "2019-09-13T00:00:00.000-0400", selected: true}
+            ],
+            attributes: {'parameter-render-type': 'datepicker'}
+          };
+          spyOn(reportPrompt, "_createFormatter").and.returnValue(undefined);
+          spyOn(reportPrompt, "_compareDatesOnly").and.returnValue(false);
+          reportPrompt._applyUserInput("anyname", ["2019-09-10T00:00:00.000"], dateSelectionParameter);
+
+          expect(dateSelectionParameter.values[1].selected).toBe(false);
+          expect(dateSelectionParameter.forceUpdate).toBe(true);
+        });
+
+        it("should not force an update if the date selection value is the same as one of the stored selections", function () {
+          var dateSelectionParameter2 = {
+            values: [
+              {value: "2019-09-13", selected: false},
+              {value: "2019-09-10T00:00:00.000-0400", selected: false}
+            ],
+            attributes: {'parameter-render-type': 'datepicker'}
+          };
+          spyOn(reportPrompt, "_createFormatter").and.returnValue(undefined);
+          spyOn(reportPrompt, "_compareDatesOnly").and.returnValue(true);
+          reportPrompt._applyUserInput("anyname", ["2019-09-10T00:00:00.000"], dateSelectionParameter2);
+
+          expect(dateSelectionParameter2.values[1].selected).toBe(true);
+          expect(dateSelectionParameter2.forceUpdate).toBe(true);
         });
 
         it("should keep parameter as is if we have only differnet timezone", function () {
@@ -511,6 +553,8 @@ define(["reportviewer/reportviewer-prompt", "reportviewer/reportviewer-logging",
             values: [{value: "2017-01-01T11:00:00.000"}],
             attributes: {"parameter-render-type": "datepicker"}
           };
+          spyOn(reportPrompt, "_createFormatter").and.returnValue(undefined);
+          spyOn(reportPrompt, "_compareDatesOnly").and.returnValue(false);
           reportPrompt._applyUserInput("anyname", "2017-01-02T11:00:00.000", param);
           expect(param.forceUpdate).toBe(true);
           var param = {


### PR DESCRIPTION
@pentaho/tatooine @ssamora @pentaho-lmartins @tmorgner 

* [BISERVER-14306] Added extra functionality and reversed logic for ParameterDependencyGraph
* [BISERVER-14306] Changed boolean logic to check for dependencies
instead of availability and in ParameterDependencyGraph checked for
instance of TableDataFactory to return an empty table instead of null
* [BISERVER-14306] Added extra check for getSelections
* [BISERVER-14306] Updated tests
* [BISERVER-14306] Updated client javascript to ensure the selected
value is set properly when switching date objects (this is generally
working, but for those date objects that have default values, this loses
it's value)
* [BISERVER-14306] Cleanup of javascript and java code

Pull Request is from a set of two PRs:
* https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/737
* https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1475