### PR TITLE
[PRD-6038] Auto-complete feature of Text Box is not working as expected when using a query to limit the results returned.

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -604,7 +604,12 @@ public class ParameterXmlContentHandler {
       // then eliminate all downstream dependencies from this list
       if ( changedParameters.contains( knownParameter ) ) {
         for ( String child : dependencies.getDependentParameterFor( knownParameter ) ) {
-          effectivelyChanged.remove( child );
+          // [PRD-6038] A query parameter in the dependency graph may write the known parameter as the child parameter
+          // In this case, we need to make sure we don't remove the true changed parameter from the effectively changed
+          // parameter
+          if ( !child.equals( knownParameter ) ) {
+            effectivelyChanged.remove( child );
+          }
         }
       }
     }

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandlerTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandlerTest.java
@@ -601,6 +601,8 @@ public class ParameterXmlContentHandlerTest {
     dependencies.addDependency( "third", "fourth" );
     //Independent parameters
     dependencies.addDependency( "fifth", "sixth" );
+    // [PRD-6038] For certain queries, test against having a dependency of itself, ensure it does not lose changed status
+    dependencies.addDependency( "first", "first" );
 
     final Element parameters = handler.document.createElement( "parameters" );
     handler.document.appendChild( parameters );


### PR DESCRIPTION
@pentaho/tatooine @RPAraujo @ssamora

* [PRD-6038] Added logic to ensure if the "child" is the same parameter name as the known Parameter. With query parameters, sometimes the dependency graph states itself as the dependency. This logic is needed to ensure we don't remove the query parameter from the effectively changed list, so it can keep any variables input by the user.

This PR is part of a set:
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1485
- https://github.com/pentaho/pentaho-platform-plugin-reporting/pull/743