### PR TITLE
[BISERVER-14290] - Schedules created on the User Console runs twice if the user scheduling does not have "Create Content" permission.

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/repository/ReportContentLocation.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/repository/ReportContentLocation.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2017 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin.repository;
@@ -98,6 +98,7 @@ public class ReportContentLocation implements ContentLocation {
       }
 
       try {
+        rfos.forceFlush( true );
         rfos.close();
       } catch ( IOException e ) {
         throw new ContentCreationException( e.getMessage(), e );


### PR DESCRIPTION
@pentaho-lmartins 
@ssamora 
@ppatricio 
@smmribeiro 
