### PR TITLE
[BACKLOG-38398] Allow users to specify the names of specific pairs of

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterDependencyGraph.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterDependencyGraph.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2019 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -278,6 +278,8 @@ public class ParameterDependencyGraph {
       analyzeFormula( extractFormula( parameterContext, pe, ParameterAttributeNames.Core.POST_PROCESSOR_FORMULA ) ) );
     retval.addAll(
       analyzeFormula( extractFormula( parameterContext, pe, ParameterAttributeNames.Core.DISPLAY_VALUE_FORMULA ) ) );
+    retval.addAll(
+      analyzeFormula( extractFormula( parameterContext, pe, ParameterAttributeNames.Core.HIDDEN_FORMULA ) ) );
     return retval;
   }
 

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/ParameterXmlContentHandler.java
@@ -12,39 +12,10 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2020 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.Serializable;
-import java.lang.reflect.Array;
-import java.math.BigDecimal;
-import java.sql.Timestamp;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.TimeZone;
-import java.util.stream.Collectors;
-
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.math.NumberUtils;
@@ -98,6 +69,34 @@ import org.pentaho.reporting.platform.plugin.output.ReportOutputHandlerFactory;
 import org.springframework.web.util.HtmlUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
 
 
 public class ParameterXmlContentHandler {
@@ -775,6 +774,25 @@ public class ParameterXmlContentHandler {
           attrElement.setAttribute( "name", "must-validate-on-server" );
           attrElement.setAttribute( "value", Boolean.TRUE.toString() );
           parameterElement.appendChild( attrElement );
+        }
+      } else {
+        // hidden param attribute still needs to be recalculated every update
+        for ( final String namespace : namespaces ) {
+          final String[] attributeNames = parameter.getParameterAttributeNames( namespace );
+          for ( final String attributeName : attributeNames ) {
+            if ( attributeName.equalsIgnoreCase( "hidden" ) ) {
+              final String attributeValue =
+                parameter.getTranslatedParameterAttribute( namespace, attributeName, parameterContext );
+              // expecting: label, parameter-render-type, parameter-layout
+              // but others possible as well, so we set them all
+              final Element attributeElement = document.createElement( "attribute" ); // NON-NLS
+              attributeElement.setAttribute( "namespace", namespace ); // NON-NLS
+              attributeElement.setAttribute( "name", attributeName ); // NON-NLS
+              attributeElement.setAttribute( "value", attributeValue ); // NON-NLS
+
+              parameterElement.appendChild( attributeElement );
+            }
+          }
         }
       }
 

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/ReportContentUtil.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/ReportContentUtil.java
@@ -12,22 +12,27 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
 
+import com.cronutils.utils.VisibleForTesting;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.pentaho.commons.connection.IPentahoResultSet;
 import org.pentaho.platform.plugin.action.jfreereport.helper.PentahoTableModel;
 import org.pentaho.platform.util.messages.LocaleHelper;
+import org.pentaho.reporting.engine.classic.core.ClassicEngineBoot;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.ReportProcessingException;
+import org.pentaho.reporting.engine.classic.core.parameters.DefaultParameterDefinition;
 import org.pentaho.reporting.engine.classic.core.parameters.ListParameter;
 import org.pentaho.reporting.engine.classic.core.parameters.ParameterAttributeNames;
 import org.pentaho.reporting.engine.classic.core.parameters.ParameterContext;
 import org.pentaho.reporting.engine.classic.core.parameters.ParameterDefinitionEntry;
+import org.pentaho.reporting.engine.classic.core.parameters.PlainParameter;
+import org.pentaho.reporting.engine.classic.core.parameters.StaticListParameter;
 import org.pentaho.reporting.engine.classic.core.parameters.ValidationMessage;
 import org.pentaho.reporting.engine.classic.core.parameters.ValidationResult;
 import org.pentaho.reporting.engine.classic.core.util.ReportParameterValues;
@@ -56,6 +61,12 @@ import java.util.TimeZone;
 public class ReportContentUtil {
 
   private static final String ONLY_DATE_REGEX_PATTERN = "(y{4}|([dM]){2})([-/])(([dM]){2})([-/])(y{4}|([dM]){2})";
+  private static final String CONFIG_START_DATE_RANGE_PARAM_NAME = "org.pentaho.reporting.engine.classic.core.scheduler.startDateRangeParamName";
+  private static final String CONFIG_END_DATE_RANGE_PARAM_NAME = "org.pentaho.reporting.engine.classic.core.scheduler.endDateRangeParamName";
+  private static String startDateParamName = ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty( CONFIG_START_DATE_RANGE_PARAM_NAME, "" );
+  private static String endDateParamName = ClassicEngineBoot.getInstance().getGlobalConfig().getConfigProperty( CONFIG_END_DATE_RANGE_PARAM_NAME, "" );
+  private static final boolean useRelativeDateParams = !startDateParamName.isEmpty() && !endDateParamName.isEmpty();
+  public static final String USE_RELATIVE_DATE_STRING = "Use Relative Date";
 
   /**
    * Apply inputs (if any) to corresponding report parameters, care is taken when checking parameter types to perform
@@ -79,7 +90,15 @@ public class ReportContentUtil {
     // apply inputs to report
     if ( inputs != null ) {
       final Log log = LogFactory.getLog( SimpleReportingComponent.class );
-      final ParameterDefinitionEntry[] params = report.getParameterDefinition().getParameterDefinitions();
+      ParameterDefinitionEntry[] params = report.getParameterDefinition().getParameterDefinitions();
+      if ( useRelativeDateParams && shouldInjectRelativeDateParams( params ) ) {
+        params = addRelativeDateFields( params, startDateParamName, endDateParamName );
+        DefaultParameterDefinition newReportParamDef = new DefaultParameterDefinition();
+        for ( ParameterDefinitionEntry entry : params ) {
+          newReportParamDef.addParameterDefinition( entry );
+        }
+        report.setParameterDefinition( newReportParamDef );
+      }
       final ReportParameterValues parameterValues = report.getParameterValues();
       for ( final ParameterDefinitionEntry param : params ) {
         final String paramName = param.getName();
@@ -100,6 +119,103 @@ public class ReportContentUtil {
       }
     }
     return validationResult;
+  }
+
+  private static String getRelCheckboxParamName( String paramName ) {
+    return paramName + "_Checkbox";
+  }
+
+  private static String getThisLastParamName( String paramName ) {
+    return paramName + "_ThisLast";
+  }
+
+  private static String getRelativeValParamName( String paramName ) {
+    return paramName + "_RelativeVal";
+  }
+
+  private static String getRelativeUnitParamName( String paramName ) {
+    return paramName + "_RelativeUnit";
+  }
+
+  protected static boolean shouldInjectRelativeDateParams(ParameterDefinitionEntry[] inputParams ) {
+    boolean hasStartDate = false;
+    boolean hasEndDate = false;
+    boolean paramsAlreadyPresent = false;
+    for ( ParameterDefinitionEntry entry : inputParams ) {
+      hasStartDate |= ( entry.getName().equalsIgnoreCase( startDateParamName ) && entry.getValueType().equals( java.util.Date.class ) );
+      hasEndDate |= ( entry.getName().equalsIgnoreCase( endDateParamName ) && entry.getValueType().equals( java.util.Date.class ) );
+      paramsAlreadyPresent |= entry.getName().equalsIgnoreCase( getRelCheckboxParamName( startDateParamName ) );
+    }
+    return hasStartDate && hasEndDate && !paramsAlreadyPresent;
+  }
+
+  protected static ParameterDefinitionEntry[] addRelativeDateFields( ParameterDefinitionEntry[] inputParams, String startDateParamName, String endDateParamName ) {
+    ParameterDefinitionEntry[] modifiedParams = new ParameterDefinitionEntry[ inputParams.length + 4 ];
+    String checkboxParamName = getRelCheckboxParamName( startDateParamName );
+
+    StaticListParameter checkboxParam = new StaticListParameter( checkboxParamName, true, true, String.class );
+    checkboxParam.setHidden( false );  // checkbox is always visible
+    checkboxParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.ROLE_USER_PARAMETER, "user" );
+    checkboxParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.TYPE, ParameterAttributeNames.Core.TYPE_CHECKBOX );
+    checkboxParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.LABEL, "Use Relative Date" );
+    checkboxParam.addValues( USE_RELATIVE_DATE_STRING, USE_RELATIVE_DATE_STRING );
+    modifiedParams[ 0 ] = checkboxParam;
+    // checkbox param existed and was true; add in the other fields
+    StaticListParameter thisLastParam = new StaticListParameter( getThisLastParamName( startDateParamName ), false, true, String.class );
+    thisLastParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.ROLE_USER_PARAMETER, "user" );
+    thisLastParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.TYPE, ParameterAttributeNames.Core.TYPE_DROPDOWN );
+    thisLastParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.LABEL, "This/Last" );
+    thisLastParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.HIDDEN_FORMULA, getRelativeDateHiddenFormulaNegated( checkboxParamName ) );
+    thisLastParam.addValues( "This", "This" );
+    thisLastParam.addValues( "Last", "Last" );
+    thisLastParam.setHidden( true );  // these will always be hidden at first
+    thisLastParam.setDefaultValue( "This" );
+    modifiedParams[ 1 ] = thisLastParam;
+    PlainParameter valueParam = new PlainParameter( getRelativeValParamName( startDateParamName ), Integer.class );
+    valueParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.ROLE_USER_PARAMETER, "user" );
+    valueParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.TYPE, ParameterAttributeNames.Core.TYPE_TEXTBOX );
+    valueParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.LABEL, "Value" );
+    valueParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.HIDDEN_FORMULA, getRelativeDateHiddenFormulaNegated( checkboxParamName) );
+    valueParam.setHidden( true );
+    valueParam.setDefaultValue( 1 );
+    modifiedParams[ 2 ] = valueParam;
+    StaticListParameter unitParam = new StaticListParameter( getRelativeUnitParamName( startDateParamName ), false, true, String.class );
+    unitParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.ROLE_USER_PARAMETER, "user" );
+    unitParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.TYPE, ParameterAttributeNames.Core.TYPE_DROPDOWN );
+    unitParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.LABEL, "Units" );
+    unitParam.setParameterAttribute( ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.HIDDEN_FORMULA, getRelativeDateHiddenFormulaNegated( checkboxParamName ) );
+    unitParam.addValues( "Days", "Days" );
+    unitParam.addValues( "Weeks", "Weeks" );
+    unitParam.addValues( "Months", "Months" );
+    unitParam.addValues( "Months (Calendar)", "Months (Calendar)" );
+    unitParam.addValues( "Quarter (Calendar)", "Quarter (Calendar)" );
+    unitParam.addValues( "Quarter (Fiscal)", "Quarter (Fiscal)" );
+    unitParam.addValues( "Months", "Months" );
+    unitParam.addValues( "Years", "Years" );
+    unitParam.addValues( "Years (Calendar)", "Years (Calendar)" );
+    unitParam.addValues( "Years (Fiscal)", "Years (Fiscal)" );
+    unitParam.setDefaultValue( "Days" );
+    unitParam.setHidden( true );
+    modifiedParams[ 3 ] = unitParam;
+    int paramIndex = 4;
+    // copy original parameters into the modified array, updating the start and end date params with the hidden formula
+    for ( ParameterDefinitionEntry entry : inputParams ) {
+      modifiedParams[ paramIndex ] = entry;
+      if ( entry.getName().equalsIgnoreCase( startDateParamName ) || entry.getName().equalsIgnoreCase( endDateParamName ) ) {
+        ( (PlainParameter)modifiedParams[ paramIndex ] ).setParameterAttribute(
+          ParameterAttributeNames.Core.NAMESPACE, ParameterAttributeNames.Core.HIDDEN_FORMULA, getRelativeDateHiddenFormula( checkboxParamName ) );
+      }
+      paramIndex++;
+    }
+    return modifiedParams;
+  }
+
+  private static String getRelativeDateHiddenFormula( String checkBoxParamName ) {
+    return "=EQUALS([" + checkBoxParamName + "];\"" + USE_RELATIVE_DATE_STRING + "\")";
+  }
+
+  private static String getRelativeDateHiddenFormulaNegated( String checkBoxParamName ) {
+    return "=NOT(EQUALS([" + checkBoxParamName + "];\"" + USE_RELATIVE_DATE_STRING + "\"))";
   }
 
   public static Object computeParameterValue( final ParameterContext parameterContext,
@@ -334,4 +450,13 @@ public class ReportContentUtil {
     return dataFormatSpec != null && dataFormatSpec.matches( ONLY_DATE_REGEX_PATTERN );
   }
 
+  @VisibleForTesting
+  protected static void setStartDateParamName( String name ) {
+    startDateParamName = name;
+  }
+
+  @VisibleForTesting
+  protected static void setEndDateParamName( String name ) {
+    endDateParamName = name;
+  }
 }

--- a/core/src/main/javascript/reportviewer/reportviewer-prompt.js
+++ b/core/src/main/javascript/reportviewer/reportviewer-prompt.js
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2021 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 define([
@@ -249,6 +249,7 @@ define([
               //Replace all changed parameters values
               paramDefn.mapParameters( function (p) {
                 oldParams.updateParameterValue(p);
+                oldParams.updateParameterAttribute(p);
               });
 
               //Replace root attributes

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/ReportContentUtilTest.java
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2002-2018 Hitachi Vantara..  All rights reserved.
+ * Copyright (c) 2002-2023 Hitachi Vantara..  All rights reserved.
  */
 
 package org.pentaho.reporting.platform.plugin;
@@ -27,56 +27,74 @@ import org.pentaho.reporting.engine.classic.core.parameters.ParameterDefinitionE
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.pentaho.di.core.util.Assert.assertTrue;
 
 public class ReportContentUtilTest {
 
-    @Mock private ParameterContext context;
+  @Mock
+  private ParameterContext context;
 
-    private ParameterDefinitionEntry pde = Mockito.mock( ParameterDefinitionEntry.class );
+  private ParameterDefinitionEntry pde = Mockito.mock( ParameterDefinitionEntry.class );
 
-    @Test
-    public void parseDateStrict_null_Test() throws Exception {
+  @Test
+  public void parseDateStrict_null_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( null );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( null );
 
-        validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 01:12:23 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 01:12:23 UTC 2018" );
+  }
 
-    @Test
-    public void parseDateStrict_GMTplus3_Test() throws Exception {
+  @Test
+  public void parseDateStrict_GMTplus3_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT+3" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT+3" );
 
-        validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 04:12:23 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sun May 20 04:12:23 UTC 2018" );
+  }
 
-    @Test
-    public void parseDateStrict_GMTminus7_Test() throws Exception {
+  @Test
+  public void parseDateStrict_GMTminus7_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT-7" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "Etc/GMT-7" );
 
-        validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sat May 19 18:12:23 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T01:12:23.456-0400", "Sat May 19 18:12:23 UTC 2018" );
+  }
 
-    @Test
-    public void parseDateStrict_server_Test() throws Exception {
+  @Test
+  public void parseDateStrict_server_Test() throws Exception {
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "client" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.TIMEZONE, null ) ).thenReturn( "client" );
 
-        when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
-                ParameterAttributeNames.Core.DATA_FORMAT, null ) ).thenReturn( "yyyy-MM-dd" );
+    when( pde.getParameterAttribute( ParameterAttributeNames.Core.NAMESPACE,
+      ParameterAttributeNames.Core.DATA_FORMAT, null ) ).thenReturn( "yyyy-MM-dd" );
 
-        validateParseDateStrict( "2018-05-20T00:00:00.000-0400", "Sun May 20 00:00:00 UTC 2018" );
-    }
+    validateParseDateStrict( "2018-05-20T00:00:00.000-0400", "Sun May 20 00:00:00 UTC 2018" );
+  }
 
-    private void validateParseDateStrict( final String dateToParse, final String dateResult ) throws Exception {
+  @Test
+  public void testRelativeDateParams() {
+    ParameterDefinitionEntry mockStartParam = mock( ParameterDefinitionEntry.class );
+    when( mockStartParam.getName() ).thenReturn( "startDate" );
+    when( mockStartParam.getValueType() ).thenReturn( java.util.Date.class );
+    ParameterDefinitionEntry mockEndParam = mock( ParameterDefinitionEntry.class );
+    when( mockEndParam.getName() ).thenReturn( "endDate" );
+    when( mockEndParam.getValueType() ).thenReturn( java.util.Date.class );
+    ReportContentUtil.setStartDateParamName( "startDate" );
+    ReportContentUtil.setEndDateParamName( "endDate" );
 
-        Date date = ReportContentUtil.parseDateStrict( pde, context, dateToParse );
-        assertEquals( dateResult, date.toString() );
-    }
+    assertTrue(
+      ReportContentUtil.shouldInjectRelativeDateParams( new ParameterDefinitionEntry[] { mockEndParam, mockStartParam } ) );
+  }
+
+  private void validateParseDateStrict( final String dateToParse, final String dateResult ) throws Exception {
+
+    Date date = ReportContentUtil.parseDateStrict( pde, context, dateToParse );
+    assertEquals( dateResult, date.toString() );
+  }
 }


### PR DESCRIPTION
date parameters that will provide the option to be set using dynamically-calculated values based on a time interval relative to the time the report is run.  Checks the classic-engine.properties file for param names and injects additional parameters when the report is scheduled to allow selecting a relative date range.