### PR TITLE
[BACKLOG-39139] Leave original default overflow in place for

### DIFF
--- a/core/src/main/javascript/reportviewer/report.html
+++ b/core/src/main/javascript/reportviewer/report.html
@@ -39,6 +39,7 @@
     var inSchedulerDialog = window.location.pathname.toLowerCase().indexOf('parameterui') >= 0;
     if (inSchedulerDialog) {
       document.documentElement.style.setProperty( '--var-default-overflow', "visible" );
+      document.documentElement.style.setProperty( '--var-prompt-panel-overflow', "visible" );
     }
 
     /**


### PR DESCRIPTION
.prompt-panel; override for scheduler dialog.