### PR TITLE
[BACKLOG-39701] Error opening chart in new window

### DIFF
--- a/core/src/main/javascript/reportviewer/reportviewer.js
+++ b/core/src/main/javascript/reportviewer/reportviewer.js
@@ -205,7 +205,7 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
           });
         }
         var url = this._buildReportContentUrl();
-        pentahoGet(window.parent.parent.pho.getSchedulerPluginContextURL() + 'api/scheduler/canSchedule', "", dojo.hitch( this, function(result) {
+        pentahoGet(window.location.protocol + "//" + window.location.host + window.CONTEXT_PATH + "plugin/scheduler-plugin/" + 'api/scheduler/canSchedule', "", dojo.hitch( this, function(result) {
           this._hasSchedulePermission = "true" == result;
           if(!this.view._isInsideDashboard() && !inMobile && this._hasSchedulePermission){
             registry.byId('feedbackScreen').showBackgroundBtn(_Messages.getString('FeedbackScreenBackground'));
@@ -975,7 +975,7 @@ define([ 'common-ui/util/util', 'common-ui/util/timeutil', 'common-ui/util/forma
         // BISERVER-14167 - To assure a very unelikly scenario where _hasSchedulePermission has not been set during load function
         if(this._hasSchedulePermission == null){
           var url = this._buildReportContentUrl();
-          var result = pentahoGet(window.parent.parent.pho.getSchedulerPluginContextURL() + 'api/scheduler/canSchedule', "", null, "application/json");
+          var result = pentahoGet(window.location.protocol + "//" + window.location.host + window.CONTEXT_PATH + "plugin/scheduler-plugin/" + 'api/scheduler/canSchedule', "", null, "application/json");
           this._hasSchedulePermission = "true" === result;
         }
 


### PR DESCRIPTION
[BACKLOG-39674] In PUC, adding a saved Interactive Report to a new Dashboard is throwing a "Fatal Error Error Parsing parameter information"

[BACKLOG-39674]: https://hv-eng.atlassian.net/browse/BACKLOG-39674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ