### PR TITLE
[BISERVER-14865] - Impossible to download PIR reports onto Excel 2007 format once data is past Excel limitations

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastXLSXOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastXLSXOutput.java
@@ -16,11 +16,16 @@
  */
 package org.pentaho.reporting.platform.plugin.output;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
+import org.pentaho.reporting.engine.classic.core.AttributeNames;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.ReportProcessingException;
 import org.pentaho.reporting.engine.classic.core.modules.output.fast.validator.ReportStructureValidator;
 import org.pentaho.reporting.engine.classic.core.modules.output.fast.xls.FastExcelExportProcessor;
 import org.pentaho.reporting.libraries.repository.ContentIOException;
+import org.pentaho.reporting.platform.plugin.SimpleReportingComponent;
 import org.pentaho.reporting.platform.plugin.async.IAsyncReportListener;
 import org.pentaho.reporting.platform.plugin.async.ReportListenerThreadHolder;
 
@@ -29,6 +34,8 @@ import java.io.OutputStream;
 
 public class FastXLSXOutput extends XLSXOutput {
   private ProxyOutputStream proxyOutputStream;
+
+
 
   public FastXLSXOutput() {
     proxyOutputStream = new ProxyOutputStream();
@@ -39,6 +46,7 @@ public class FastXLSXOutput extends XLSXOutput {
                        final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException {
     proxyOutputStream.setParent( outputStream );
+    overrideQueryLimit( report );
     final IAsyncReportListener listener = ReportListenerThreadHolder.getListener();
     ReportStructureValidator validator = new ReportStructureValidator();
     if ( validator.isValidForFastProcessing( report ) == false ) {
@@ -50,6 +58,11 @@ public class FastXLSXOutput extends XLSXOutput {
     doProcess( listener, reportProcessor );
     outputStream.flush();
     return 0;
+  }
+
+  // Functionality requested by BISERVER-14865
+  private void overrideQueryLimit( MasterReport report ) {
+    report.setQueryLimit( getPropertyValue( "excel-query-limit", "-1" ) );
   }
 
   public int paginate( final MasterReport report,

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/XLSXOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/XLSXOutput.java
@@ -17,6 +17,9 @@
 
 package org.pentaho.reporting.platform.plugin.output;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.pentaho.platform.engine.core.system.PentahoSystem;
 import org.pentaho.reporting.engine.classic.core.MasterReport;
 import org.pentaho.reporting.engine.classic.core.ReportProcessingException;
 import org.pentaho.reporting.engine.classic.core.modules.output.table.base.FlowReportProcessor;
@@ -35,6 +38,8 @@ import java.io.OutputStream;
 public class XLSXOutput implements ReportOutputHandler {
   private byte[] templateData;
   private ProxyOutputStream proxyOutputStream;
+
+  final Log log = LogFactory.getLog( FastXLSXOutput.class );
 
   public XLSXOutput() {
   }
@@ -69,6 +74,8 @@ public class XLSXOutput implements ReportOutputHandler {
     final FlowExcelOutputProcessor target =
       new FlowExcelOutputProcessor( report.getConfiguration(), proxyOutputStream, report.getResourceManager() );
     target.setUseXlsxFormat( true );
+    target.setMaxSheetRowCount( getPropertyValue( "excel-sheet-limit", "-1" ) );
+
     final FlowReportProcessor reportProcessor = new FlowReportProcessor( report, target );
 
     if ( yieldRate > 0 ) {
@@ -120,5 +127,15 @@ public class XLSXOutput implements ReportOutputHandler {
   }
 
   public void close() {
+  }
+
+  public int getPropertyValue( String propName, String def ) {
+    String limit = PentahoSystem.getSystemSetting( "pentaho-interactive-reporting/settings.xml", propName, def );
+    try {
+      return Integer.parseInt( limit );
+    } catch ( NumberFormatException e ) {
+      log.error( "'" + propName + "' defined incorrectly in the settings.xml" );
+      return -1;
+    }
   }
 }


### PR DESCRIPTION
Adding support for new Excel export settings.
See: https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/1045