### PR TITLE
[TEST] Unit test fixes for JDK17

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -222,6 +222,11 @@
       <artifactId>org.osgi.core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stephenc.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- region - Needed for IT testing -->
     <dependency>
       <groupId>org.springframework</groupId>

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/async/PentahoAsyncReportExecutorTest.java
@@ -20,9 +20,12 @@ package org.pentaho.reporting.platform.plugin.async;
 
 import com.google.common.io.CharStreams;
 import junit.framework.Assert;
+import net.jcip.annotations.NotThreadSafe;
 import org.junit.*;
 import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.mockito.stubbing.Answer;
 import org.pentaho.commons.util.repository.exception.RuntimeException;
 import org.pentaho.platform.api.engine.IApplicationContext;
@@ -72,6 +75,8 @@ import static org.mockito.Mockito.*;
  * <p>
  * Created by dima.prokopenko@gmail.com on 2/17/2016.
  */
+@RunWith( MockitoJUnitRunner.class )
+@NotThreadSafe
 public class PentahoAsyncReportExecutorTest {
 
   @Rule public Timeout globalTimeout = new Timeout( 10000 );
@@ -126,8 +131,8 @@ public class PentahoAsyncReportExecutorTest {
     input = new AsyncJobFileStagingHandler.FixedSizeStagingContent( temp );
 
     when( handler.getStagingContent() ).thenReturn( input );
-    when( report.getReportConfiguration() ).thenReturn( configuration );
-    when( component.getReport() ).thenReturn( report );
+    lenient().when( report.getReportConfiguration() ).thenReturn( configuration );
+    lenient().when( component.getReport() ).thenReturn( report );
 
     when( session1.getId() ).thenReturn( sessionUid1.toString() );
     when( session2.getId() ).thenReturn( sessionUid2.toString() );

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     <javax.ws.rs-api.version>2.0</javax.ws.rs-api.version>
     <javax.servlet-api.version>3.0.1</javax.servlet-api.version>
     <commons-io.version>2.16.1</commons-io.version>
+    <jcip-annotations.version>1.0-1</jcip-annotations.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -405,6 +406,12 @@
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${javax.servlet-api.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.github.stephenc.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <version>${jcip-annotations.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
There's a race condition when multiple tests in PentahoAsyncReportExecutorTest are run at the same time. The only way to run these one at a time without slowing every other test in the module to a crawl is the `@NotThreadSafe` annotation.

The new dependency is a re-implementation of the original library, which used a problematic license. Check the [readme](https://github.com/stephenc/jcip-annotations) in the repo for more information.