### PR TITLE
[PRD-6173] - RowLimit while exporting Excel for PRD report is not working in PUC

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/EmailOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/EmailOutput.java
@@ -63,7 +63,7 @@ public class EmailOutput implements ReportOutputHandler {
       return -1;
     }
 
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     try {
 
       final Configuration configuration = report.getConfiguration();

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastCSVOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastCSVOutput.java
@@ -42,7 +42,7 @@ public class FastCSVOutput extends CSVOutput {
                        final OutputStream outputStream,
                        final int yieldRate )
     throws ReportProcessingException, IOException, ContentIOException {
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     final IAsyncReportListener listener = ReportListenerThreadHolder.getListener();
     final ReportStructureValidator validator = new ReportStructureValidator();
     if ( validator.isValidForFastProcessing( report ) == false ) {

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastStreamHtmlOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastStreamHtmlOutput.java
@@ -34,7 +34,7 @@ public class FastStreamHtmlOutput extends StreamHtmlOutput {
                        final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException, ContentIOException {
 
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     ReportStructureValidator validator = new ReportStructureValidator();
     if ( validator.isValidForFastProcessing( report ) == false ) {
       return super.generate( report, acceptedPage, outputStream, yieldRate );

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastStreamJcrHtmlOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastStreamJcrHtmlOutput.java
@@ -34,7 +34,7 @@ public class FastStreamJcrHtmlOutput extends StreamJcrHtmlOutput {
                        final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException, ContentIOException {
     ReportStructureValidator validator = new ReportStructureValidator();
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     if ( validator.isValidForFastProcessing( report ) == false ) {
       return super.generate( report, acceptedPage, outputStream, yieldRate );
     }

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastXLSXOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/FastXLSXOutput.java
@@ -38,7 +38,7 @@ public class FastXLSXOutput extends XLSXOutput {
                        final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException {
     proxyOutputStream.setParent( outputStream );
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     final IAsyncReportListener listener = ReportListenerThreadHolder.getListener();
     ReportStructureValidator validator = new ReportStructureValidator();
     if ( validator.isValidForFastProcessing( report ) == false ) {

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/OutputUtils.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/OutputUtils.java
@@ -23,21 +23,38 @@ public final class OutputUtils {
 
   static final Log log = LogFactory.getLog( PDFOutput.class );
 
-  public static void overrideQueryLimit( MasterReport report ) {
-    report.setQueryLimit( getPropertyValue( "export-query-limit", report.getQueryLimit()  ) );
+  public static void enforceQueryLimit( MasterReport report ) {
+    report.setQueryLimit( getPropertyValue( "export-query-limit", report.getQueryLimit() ) );
   }
 
-  private static int getPropertyValue( String propName, int def ) {
-    String limit = PentahoSystem.getSystemSetting( "pentaho-interactive-reporting/settings.xml", propName, String.valueOf( def ) );
+  private static int getPropertyValue( String propName, int reportLimit ) {
+    String setting = PentahoSystem.getSystemSetting( "pentaho-interactive-reporting/settings.xml", propName, "-1" );
+
+    int settingsLimit = -1;
     try {
-      int iLimit = Integer.parseInt( limit );
-      if ( iLimit <= 0 ) {
-        return -1;
-      }
-      return iLimit;
+      settingsLimit = Integer.parseInt( setting );
     } catch ( NumberFormatException e ) {
-      log.error( "'" + propName + "' defined incorrectly in the 'settings.xml'. Using default value: " + def );
-      return def;
+      log.error( "'" + propName + "' defined incorrectly in the 'settings.xml'");
     }
+
+    return getMinLimit(reportLimit, settingsLimit);
+  }
+
+  private static int getMinLimit ( int a, int b ) {
+    // Return -1 when both are "no limit"
+    if (a <= 0 && b <= 0) {
+      return -1;
+    }
+
+    // Return one if the other is "no limit"
+    if (a <= 0) {
+      return b;
+    }
+    if (b <= 0) {
+      return a;
+    }
+
+    // Return the minimum when both are positive
+    return Math.min(a, b);
   }
 }

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/PDFOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/PDFOutput.java
@@ -50,7 +50,7 @@ public class PDFOutput implements ReportOutputHandler {
 
   public int generate( final MasterReport report, final int acceptedPage, final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException {
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     final PageableReportProcessor proc = createProcessor( report, yieldRate, outputStream );
     final IAsyncReportListener listener = ReportListenerThreadHolder.getListener();
     doProcess( listener, proc );

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/PNGOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/PNGOutput.java
@@ -55,7 +55,7 @@ public class PNGOutput implements ReportOutputHandler {
 
   public int generate( final MasterReport report, final int acceptedPage, final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException, ContentIOException {
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     //TODO listener for async mode
     if ( proc == null ) {
       proc = create( report, yieldRate );

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/PlainTextOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/PlainTextOutput.java
@@ -42,7 +42,7 @@ public class PlainTextOutput implements ReportOutputHandler {
 
   public int generate( final MasterReport report, final int acceptedPage, final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException, ContentIOException {
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     final PageableReportProcessor proc = create( report, yieldRate );
     proxyOutputStream.setParent( outputStream );
     final IAsyncReportListener listener = ReportListenerThreadHolder.getListener();

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/RTFOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/RTFOutput.java
@@ -39,7 +39,7 @@ public class RTFOutput implements ReportOutputHandler {
 
   public int generate( final MasterReport report, final int acceptedPage, final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException {
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     final FlowRTFOutputProcessor target =
       new FlowRTFOutputProcessor( report.getConfiguration(), outputStream, report.getResourceManager() );
     final FlowReportProcessor proc = new FlowReportProcessor( report, target );

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/XmlPageableOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/XmlPageableOutput.java
@@ -59,7 +59,7 @@ public class XmlPageableOutput implements ReportOutputHandler {
 
   public int generate( final MasterReport report, final int acceptedPage, final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException {
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     if ( proc == null ) {
       proc = createProcessor( report, yieldRate );
     }

--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/XmlTableOutput.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/XmlTableOutput.java
@@ -55,7 +55,7 @@ public class XmlTableOutput implements ReportOutputHandler {
   public int generate( final MasterReport report, final int acceptedPage, final OutputStream outputStream,
                        final int yieldRate ) throws ReportProcessingException, IOException {
 
-    OutputUtils.overrideQueryLimit( report );
+    OutputUtils.enforceQueryLimit( report );
     if ( proc == null ) {
       proc = createProcessor( report, yieldRate );
     }


### PR DESCRIPTION
Instead of using the value that comes from the settings to override the value coming from the report, we are now using both as limits, meaning that we take the minimum of the 2 and use it as our `RowLimit`