### PR TITLE
fix: incorrect mantle frame detection breaks session-timeout handling [PPUC-108][BISERVER-14841]

### DIFF
--- a/core/src/main/javascript/reportviewer/reportviewer-prompt.js
+++ b/core/src/main/javascript/reportviewer/reportviewer-prompt.js
@@ -437,7 +437,7 @@ define([
 
       reauthenticate: function(f) {
 
-        if(isRunningIFrameInSameOrigin) {
+        if(isRunningIFrameInSameOrigin && typeof window.parent.authenticate === 'function') {
           var callback = {
             loginCallback : f
           }


### PR DESCRIPTION
- NPE thrown upon reauthentication, when PIR is opened standalone
- when embedded in, PUC, typically, PUC's every 10s session-timeout detection opens a modal session timeout dialog which prevents PIR's local handling to take effect

Part of PR set: https://github.com/pentaho/pentaho-platform/pull/5915

@pentaho/millenniumfalcon, please, review.