### PR TITLE
[BACKLOG-44501] fix: update DATEVALUE regex to preserve outer parentheses

### DIFF
--- a/core/src/main/java/org/pentaho/reporting/platform/plugin/output/util/ReadableFilterUtil.java
+++ b/core/src/main/java/org/pentaho/reporting/platform/plugin/output/util/ReadableFilterUtil.java
@@ -40,7 +40,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class ReadableFilterUtil {
-  private static final String DATEVALUE = "\\(?DATEVALUE\\((.*?)\\)\\)?";
+  private static final String DATEVALUE = "\\bDATEVALUE\\((.*?)\\)";
   private static final String SPACE = " ";
 
   private static final ReadableFilterUtil INSTANCE = new ReadableFilterUtil();

--- a/core/src/test/java/org/pentaho/reporting/platform/plugin/output/util/ReadableFilterUtilTest.java
+++ b/core/src/test/java/org/pentaho/reporting/platform/plugin/output/util/ReadableFilterUtilTest.java
@@ -165,7 +165,7 @@ public class ReadableFilterUtilTest {
     assertEquals( "((Product Line Exactly matches value of Prompt Product Line OR Country Excludes (\"Australia\", "
       + "\"Belgium\", \"Canada\", \"Finland\")) AND Territory Includes (value of Prompt Territory) "
       + "AND Buy Price (SUM) Less Than 10000 AND Required Date On "
-      + "value of Prompt Required Date AND Payment Date On or before value of Prompt payDate", result );
+      + "value of Prompt Required Date AND Payment Date On or before value of Prompt payDate)", result );
   }
 
   @Test


### PR DESCRIPTION
 Updated the `DATEVALUE` regular expression to use word boundaries (`\b`) instead of optional parentheses for better accuracy in matching expressions