### PR TITLE
fix[PPN-367]: integration tests were not compiling

### DIFF
--- a/core/src/it/java/org/pentaho/reporting/platform/plugin/ParameterIT.java
+++ b/core/src/it/java/org/pentaho/reporting/platform/plugin/ParameterIT.java
@@ -127,7 +127,7 @@ public class ParameterIT {
   public void testParameterProcessing() throws Exception {
     final ParameterContentGenerator contentGenerator = new ParameterContentGenerator();
     final ParameterXmlContentHandler handler = new ParameterXmlContentHandler( contentGenerator, false );
-    handler.createParameterContent( System.out, "target/test/solution/test/reporting/Product Sales.prpt",
+    handler.createParameterContent( System.out, "target/test/solution/test/reporting/Product Sales.prpt", null,
       PentahoSystem.getApplicationContext().getSolutionPath( "target/test/solution/test/reporting/Product Sales.prpt" ), false, null );
   }
 
@@ -147,7 +147,7 @@ public class ParameterIT {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     final ParameterContentGenerator contentGenerator = new ParameterContentGenerator();
     final ParameterXmlContentHandler handler = new ParameterXmlContentHandler( contentGenerator, false );
-    handler.createParameterContent( baos, "/test/reporting/prd3882.prpt",
+    handler.createParameterContent( baos, "/test/reporting/prd3882.prpt", null,
       "target/test/resource/solution/test/reporting/prd3882.prpt", false, null );
 
     DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();


### PR DESCRIPTION
@peterrinehart, the changes introduced under [PPN-367](https://hv-eng.atlassian.net/browse/PPN-367) added a new parameter to the createParameterContent method and that was not reflected on this class (check Integration Test execution [here](https://thanos.orl.eng.hitachivantara.com/job/11.1/job/it-snapshot-jobs/job/platform-reporting-plugin/64/console)).
I've added 'null' as a parameter on both invocations. Please advise if this is not the appropriate value.

@peterrinehart 

[PPN-367]: https://hv-eng.atlassian.net/browse/PPN-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ